### PR TITLE
Update timestamp handling to use ISO-8601 format with timezone support

### DIFF
--- a/docs/api-json.md
+++ b/docs/api-json.md
@@ -32,7 +32,7 @@ Most payloads are built from [`get_info()`](../firmware/models/ld_product_model.
 ```json
 {
   "device": {
-    "time": "2026-04-16T12:00:00.000Z",
+    "time": "2026-04-16T14:00:00.000+02:00",
     "device": "<device_id>",
     "firmware": "<major>.<minor>.<patch>",
     "model": <integer model id>,
@@ -45,7 +45,7 @@ Most payloads are built from [`get_info()`](../firmware/models/ld_product_model.
 }
 ```
 
-- **`time`**: ISO-like UTC string from `time.localtime()` (not necessarily true UTC without NTP/RTC).
+- **`time`**: ISO-8601 string from [`format_iso8601_tz()`](../firmware/tz_format.py): `…Z` when `TZ` is UTC (or `GMT` / `Etc/UTC`), otherwise local civil time for **`Europe/Vienna`** (default if `TZ` is unset) with suffix **`+01:00`** or **`+02:00`** (EU DST). Based on `time.time()`; RTC should be **UTC** after NTP (`tz_offset=0`). See [`docs/settings.md`](settings.md) (`TZ`).
 - **`model`**: [`LdProduct`](../firmware/enums.py) integer (e.g. Air Station = 3).
 - **`sensors`**: Empty object here; filled in [`get_json()`](../firmware/models/ld_product_model.py).
 
@@ -152,7 +152,7 @@ After draining measurement queues, [`send_to_api`](../firmware/models/ld_product
   "sensors": {},
   "status_list": [
     {
-      "time": "2026-04-16T12:00:00.000Z",
+      "time": "2026-04-16T14:00:00.000+02:00",
       "level": <0–4 int, LOG_LEVELS>,
       "message": "<string>"
     }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -62,6 +62,7 @@ Per-device and user-facing options: Wi‑Fi, model, keys, Air Station behaviour,
 | `WIFILESS_MODE` | boolean / string | **Air Station only:** if true, skip normal Wi‑Fi/API loop and log measurements to SD (see [`readme.md`](../firmware/readme.md)). String values `1` / `true` / `yes` (case-insensitive) are accepted. |
 | `SD_LOG_PATH` | string | **Air Station wifiless:** JSONL log path (default `/sd/measurements.jsonl`). |
 | `ROLLBACK` | boolean | Set by the upgrade path / `code.py` to force booting the previous firmware bundle after a failed update. |
+| `TZ` | string | Time zone for API and log timestamps. **Default:** `Europe/Vienna` if unset or empty. Recognised values: `UTC` / `GMT` / `Etc/UTC` / `Zulu` (case-insensitive) → timestamps end with `Z`; `Europe/Vienna` → EU DST rules, suffix `+01:00` or `+02:00`. Any other name falls back to Vienna. Requires `time.time()` / RTC to reflect **UTC** after NTP (`tz_offset=0`). |
 
 ### `MODEL` values (`LdProduct`)
 

--- a/firmware/config.py
+++ b/firmware/config.py
@@ -78,6 +78,9 @@ class Config:
         'WIFILESS_MODE': 'settings.toml',
         'SD_LOG_PATH': 'settings.toml',
 
+        # IANA-style name; only UTC and Europe/Vienna are interpreted (unknown → Vienna)
+        'TZ': 'settings.toml',
+
         # UGM rollback flag (written by upgrade manager; see code.py)
         'ROLLBACK': 'settings.toml',
 
@@ -132,6 +135,8 @@ class Config:
 
         'WIFILESS_MODE': False,
         'SD_LOG_PATH': '/sd/measurements.jsonl',
+
+        'TZ': 'Europe/Vienna',
 
         'ROLLBACK': False,
 

--- a/firmware/logger.py
+++ b/firmware/logger.py
@@ -1,6 +1,7 @@
-import time
 import json
 import storage
+
+from tz_format import format_iso8601_tz
 
 # Define the log levels
 LOG_LEVELS = {
@@ -19,9 +20,7 @@ class SimpleLogger:
     def log(self, message, level='DEBUG'):
         level_num = LOG_LEVELS.get(level, 0)
         if level_num >= self.level:
-            # Get current time in the desired format
-            current_time = time.localtime()
-            formatted_time = f"{current_time.tm_year:04}-{current_time.tm_mon:02}-{current_time.tm_mday:02}T{current_time.tm_hour:02}:{current_time.tm_min:02}:{current_time.tm_sec:02}.000Z"
+            formatted_time = format_iso8601_tz()
             
             log_message = f"{formatted_time} [{level}] {message}"
             print(log_message)  # Print to console or handle as needed

--- a/firmware/models/ld_product_model.py
+++ b/firmware/models/ld_product_model.py
@@ -1,4 +1,3 @@
-import time
 import storage
 import json
 import os
@@ -7,6 +6,7 @@ import gc
 from logger import logger
 from wifi_client import WifiUtil
 from config import Config
+from tz_format import format_iso8601_tz
 from sensors.sensor import Sensor
 
 # Top-level JSON key for device metadata in API/BLE payloads (historically "station").
@@ -71,8 +71,7 @@ class LdProductModel:
     
     def get_info(self):
         """returns json with device info for api"""
-        current_time = time.localtime()
-        formatted_time = f"{current_time.tm_year:04}-{current_time.tm_mon:02}-{current_time.tm_mday:02}T{current_time.tm_hour:02}:{current_time.tm_min:02}:{current_time.tm_sec:02}.000Z"
+        formatted_time = format_iso8601_tz()
 
         device_info = {
             API_JSON_DEVICE_KEY: {
@@ -94,9 +93,8 @@ class LdProductModel:
         self.measurements[tag] = self.measurements.get(tag, []) + [data]
         '''
         storage.remount('/', False)
-        current_time = time.localtime()
-        formatted_time = f"{current_time.tm_year:04}-{current_time.tm_mon:02}-{current_time.tm_mday:02}T{current_time.tm_hour:02}:{current_time.tm_min:02}:{current_time.tm_sec:02}.000Z"
-        file_name = formatted_time.replace(':', '_').replace('.', '_')
+        formatted_time = format_iso8601_tz()
+        file_name = formatted_time.replace(':', '_').replace('.', '_').replace('+', '_')
         with open(f'{Config.runtime_settings["JSON_QUEUE"]}/{file_name}_{tag}.json', 'w') as f:
             json.dump(data, f)
         storage.remount('/', False)

--- a/firmware/settings.toml
+++ b/firmware/settings.toml
@@ -4,6 +4,9 @@ SSID = ""
 PASSWORD = ""
 SEND_TO_SENSOR_COMMUNITY = false
 
+# Timestamps for API/logs: default Europe/Vienna if omitted. See docs/settings.md (TZ).
+# TZ = "UTC"
+
 # Air Station: SD log instead of API (SPI SCK=IO12 MISO=IO11 MOSI=IO10 CS=IO13). DS3231 uses I2C from SCL/SDA in settings.
 WIFILESS_MODE = false
 # SD_LOG_PATH = "/sd/measurements.jsonl"

--- a/firmware/startup_actions.py
+++ b/firmware/startup_actions.py
@@ -2,7 +2,6 @@
 import errno
 import json
 import os
-import time
 
 import gc
 import storage
@@ -11,6 +10,7 @@ from storage import remount
 
 from config import Config
 from logger import logger
+from tz_format import format_iso8601_tz
 from wifi_client import WifiUtil
 
 STARTUP_TOML = "/startup.toml"
@@ -69,11 +69,7 @@ def _append_datahub_upload_log(msg: str) -> None:
 
 
 def _datahub_upload_timestamp() -> str:
-    lt = time.localtime()
-    return (
-        f"{lt.tm_year:04d}-{lt.tm_mon:02d}-{lt.tm_mday:02d}T"
-        f"{lt.tm_hour:02d}:{lt.tm_min:02d}:{lt.tm_sec:02d}Z"
-    )
+    return format_iso8601_tz()
 
 
 def _datahub_response_body_snippet(resp, max_len: int = 480) -> str:

--- a/firmware/tz_format.py
+++ b/firmware/tz_format.py
@@ -1,0 +1,174 @@
+"""
+ISO-8601 timestamps with a real UTC offset suffix for API and logs.
+
+CircuitPython has no ``time.gmtime`` in the usual build; we use integer calendar
+math from the Unix epoch. ``Europe/Vienna`` follows EU daylight saving (last
+Sunday of March / October at 01:00 UTC).
+
+RTC should track **UTC** when set via NTP (``tz_offset=0`` in ``wifi_client``).
+If the RTC is wrong, formatted times are wrong.
+"""
+
+import time
+
+_DEFAULT_TZ = "Europe/Vienna"
+
+
+def _effective_tz_name(settings) -> str:
+    raw = settings.get("TZ") if settings is not None else None
+    if raw is None:
+        return _DEFAULT_TZ
+    s = str(raw).strip()
+    return s if s else _DEFAULT_TZ
+
+
+def _normalize_tz_id(name: str) -> str:
+    n = name.strip().lower()
+    if n in ("utc", "gmt", "etc/utc", "etc/gmt", "etc/gmt+0", "etc/gmt-0", "zulu"):
+        return "utc"
+    if n in ("europe/vienna",):
+        return "vienna"
+    return "vienna"
+
+
+def _is_leap(y: int) -> bool:
+    return y % 4 == 0 and (y % 100 != 0 or y % 400 == 0)
+
+
+def _days_in_month(y: int, m: int) -> int:
+    dim = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    d = dim[m - 1]
+    if m == 2 and _is_leap(y):
+        d += 1
+    return d
+
+
+def _timegm(y: int, mo: int, d: int, h: int, mi: int, s: int) -> int:
+    """Seconds since 1970-01-01 00:00 UTC for the given UTC civil time."""
+    days = 0
+    for yy in range(1970, y):
+        days += 366 if _is_leap(yy) else 365
+    for mm in range(1, mo):
+        days += _days_in_month(y, mm)
+    days += d - 1
+    return days * 86400 + h * 3600 + mi * 60 + s
+
+
+def _weekday_from_utc_date(y: int, mo: int, d: int) -> int:
+    """Monday=0 .. Sunday=6 (matches ``time.struct_time``)."""
+    t = _timegm(y, mo, d, 12, 0, 0)
+    days1970 = t // 86400
+    w = (3 + days1970) % 7
+    return w
+
+
+def _last_sunday_dom(y: int, month: int) -> int:
+    d = _days_in_month(y, month)
+    while _weekday_from_utc_date(y, month, d) != 6:
+        d -= 1
+    return d
+
+
+def _eu_dst_start_utc(y: int) -> int:
+    """EU summer time begins: last Sunday in March at 01:00 UTC."""
+    d = _last_sunday_dom(y, 3)
+    return _timegm(y, 3, d, 1, 0, 0)
+
+
+def _eu_dst_end_utc(y: int) -> int:
+    """EU summer time ends: last Sunday in October at 01:00 UTC."""
+    d = _last_sunday_dom(y, 10)
+    return _timegm(y, 10, d, 1, 0, 0)
+
+
+def _utc_ymd_from_epoch(secs: int):
+    """Break non-negative epoch seconds into UTC calendar components."""
+    if secs < 0:
+        return None
+    days, sod = divmod(secs, 86400)
+    y = 1970
+    while True:
+        dy = 366 if _is_leap(y) else 365
+        if days < dy:
+            break
+        days -= dy
+        y += 1
+    m = 1
+    while m <= 12:
+        dm = _days_in_month(y, m)
+        if days < dm:
+            break
+        days -= dm
+        m += 1
+    d = days + 1
+    h, rem = divmod(sod, 3600)
+    mi, s = divmod(rem, 60)
+    return (y, m, d, h, mi, s)
+
+
+def _vienna_offset_seconds(utc_epoch: int) -> int:
+    """CET +3600 s, CEST +7200 s (EU rules)."""
+    if utc_epoch < 0:
+        return 3600
+    parts = _utc_ymd_from_epoch(utc_epoch)
+    if parts is None:
+        return 3600
+    y = parts[0]
+    for yy in (y - 1, y, y + 1):
+        if yy < 1970:
+            continue
+        start = _eu_dst_start_utc(yy)
+        end = _eu_dst_end_utc(yy)
+        if start <= utc_epoch < end:
+            return 7200
+    return 3600
+
+
+def _fmt_offset(offset_sec: int) -> str:
+    if offset_sec == 0:
+        return "Z"
+    sign = "+" if offset_sec >= 0 else "-"
+    o = abs(offset_sec)
+    h = o // 3600
+    mi = (o % 3600) // 60
+    return f"{sign}{h:02d}:{mi:02d}"
+
+
+def _format_naive_local_z() -> str:
+    """Fallback if epoch math fails (should be rare)."""
+    lt = time.localtime()
+    return (
+        f"{lt.tm_year:04d}-{lt.tm_mon:02d}-{lt.tm_mday:02d}T"
+        f"{lt.tm_hour:02d}:{lt.tm_min:02d}:{lt.tm_sec:02d}.000Z"
+    )
+
+
+def format_iso8601_tz(settings=None) -> str:
+    """
+    Current instant as ``YYYY-MM-DDTHH:MM:SS.000Z`` (UTC) or
+    ``…000+01:00`` / ``…000+02:00`` for Europe/Vienna.
+    """
+    if settings is None:
+        from config import Config
+
+        settings = Config.settings
+    tz = _normalize_tz_id(_effective_tz_name(settings))
+    try:
+        t = int(time.time())
+    except (TypeError, ValueError):
+        t = 0
+
+    if tz == "utc":
+        parts = _utc_ymd_from_epoch(t)
+        if parts is None:
+            return _format_naive_local_z()
+        y, mo, d, h, mi, s = parts
+        return f"{y:04d}-{mo:02d}-{d:02d}T{h:02d}:{mi:02d}:{s:02d}.000Z"
+
+    o = _vienna_offset_seconds(t)
+    tw = t + o
+    parts = _utc_ymd_from_epoch(tw)
+    if parts is None:
+        return _format_naive_local_z()
+    y, mo, d, h, mi, s = parts
+    return f"{y:04d}-{mo:02d}-{d:02d}T{h:02d}:{mi:02d}:{s:02d}.000{_fmt_offset(o)}"

--- a/firmware/ugm/config.py
+++ b/firmware/ugm/config.py
@@ -77,6 +77,8 @@ class Config:
         'SDA': 'settings.toml',
         'BUTTON_PIN': 'settings.toml',
 
+        'TZ': 'settings.toml',
+
         'CERTIFICATE_PATH': 'boot.toml',
 
         'ROLLBACK': 'settings.toml'
@@ -130,6 +132,8 @@ class Config:
         'SCL': None,
         'SDA': None,
         'BUTTON_PIN': None,
+
+        'TZ': 'Europe/Vienna',
 
         'CERTIFICATE_PATH': 'certs/isrgrootx1.pem',
 


### PR DESCRIPTION
This commit introduces a new module for formatting timestamps in ISO-8601 format, accommodating local time zones, specifically for Europe/Vienna. The `time` handling in various firmware components has been refactored to utilize this new formatting function, ensuring consistent timestamp representation across API responses and logs. Additionally, the configuration now includes a `TZ` setting to specify the time zone, defaulting to Europe/Vienna if not set. Documentation has been updated to reflect these changes.