### PR TITLE
Add LOG_LEVEL configuration for enhanced logging control

### DIFF
--- a/deploy/settings.toml
+++ b/deploy/settings.toml
@@ -4,6 +4,7 @@ TEST_MODE = false
 SSID = "luftdaten.at"
 PASSWORD = "clientpassword"
 SEND_TO_SENSOR_COMMUNITY = false
+LOG_LEVEL = "DEBUG"
 CALIBRATION_MODE = false
 
 # Air Station only: log measurements to SPI SD (no WiFi/API). DS3231 on the same I2C as SCL/SDA for time at boot.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -50,6 +50,7 @@ Per-device and user-facing options: Wi‑Fi, model, keys, Air Station behaviour,
 | `TEST_MODE` | boolean | If true: staging station URL, staging datahub, staging update server, and related test endpoints. |
 | `CALIBRATION_MODE` | boolean / null | Calibration flag from settings or API. If `null`, runtime calibration is inferred when `SSID == "luftdaten.at"`. |
 | `SEND_TO_SENSOR_COMMUNITY` | boolean | When true (Air Station path), also push to Sensor.Community in addition to other telemetry. |
+| `LOG_LEVEL` | string | Minimum log level for [`SimpleLogger`](../firmware/logger.py): `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive). Messages below this are not printed or added to `logger.log_list`. Default **`DEBUG`**. Unknown values are treated like **`DEBUG`**. |
 | `longitude` | string | Air Station / location: longitude (string in settings; APIs normalize to float or null). |
 | `latitude` | string | Air Station / location: latitude. |
 | `height` | string | Air Station / location: height above sea level. |

--- a/firmware/config.py
+++ b/firmware/config.py
@@ -61,6 +61,7 @@ class Config:
         'DATAHUB_API_URL': 'boot.toml',
         'DATAHUB_TEST_API_URL': 'boot.toml',
         'SEND_TO_SENSOR_COMMUNITY': 'settings.toml',
+        'LOG_LEVEL': 'settings.toml',
 
         # AirStationConfig must not be specified in settings.toml
         'longitude': 'settings.toml',
@@ -120,6 +121,7 @@ class Config:
         'DATAHUB_API_URL': None,
         'DATAHUB_TEST_API_URL': None,
         'SEND_TO_SENSOR_COMMUNITY': None,
+        'LOG_LEVEL': 'DEBUG',
 
         # AirStationConfig must not be specified in settings.toml
         'longitude': "",

--- a/firmware/logger.py
+++ b/firmware/logger.py
@@ -12,14 +12,28 @@ LOG_LEVELS = {
     'CRITICAL': 4
 }
 
+
+def _configured_log_threshold():
+    """Minimum level from ``settings.toml`` ``LOG_LEVEL`` (default DEBUG). Unknown → DEBUG."""
+    try:
+        from config import Config
+
+        raw = Config.settings.get('LOG_LEVEL', 'DEBUG')
+    except Exception:
+        return 0
+    if raw is None:
+        return 0
+    name = str(raw).strip().upper()
+    return LOG_LEVELS.get(name, 0)
+
+
 class SimpleLogger:
-    def __init__(self, level='DEBUG'):
-        self.level = LOG_LEVELS.get(level, 0)  # Default to DEBUG level
+    def __init__(self):
         self.log_list = []
 
     def log(self, message, level='DEBUG'):
         level_num = LOG_LEVELS.get(level, 0)
-        if level_num >= self.level:
+        if level_num >= _configured_log_threshold():
             formatted_time = format_iso8601_tz()
             
             log_message = f"{formatted_time} [{level}] {message}"
@@ -61,5 +75,5 @@ class SimpleLogger:
         """Format the message from a list of arguments with spaces."""
         return ' '.join(str(arg) for arg in args)
 
-# Create a global logger instance
-logger = SimpleLogger(level='DEBUG')  # Set your desired default log level
+# Global logger; threshold from ``Config.settings['LOG_LEVEL']`` (see ``config.py``).
+logger = SimpleLogger()

--- a/firmware/settings.toml
+++ b/firmware/settings.toml
@@ -3,6 +3,7 @@ TEST_MODE = false
 SSID = ""
 PASSWORD = ""
 SEND_TO_SENSOR_COMMUNITY = false
+# LOG_LEVEL = "INFO"
 
 # Timestamps for API/logs: default Europe/Vienna if omitted. See docs/settings.md (TZ).
 # TZ = "UTC"

--- a/firmware/ugm/config.py
+++ b/firmware/ugm/config.py
@@ -64,6 +64,7 @@ class Config:
         'DATAHUB_API_URL': 'boot.toml',
         'DATAHUB_TEST_API_URL': 'boot.toml',
         'SEND_TO_SENSOR_COMMUNITY': 'settings.toml',
+        'LOG_LEVEL': 'settings.toml',
 
         # AirStationConfig must not be specified in settings.toml
         'longitude': 'settings.toml',
@@ -120,6 +121,7 @@ class Config:
         'DATAHUB_API_URL': None,
         'DATAHUB_TEST_API_URL': None,
         'SEND_TO_SENSOR_COMMUNITY': None,
+        'LOG_LEVEL': 'DEBUG',
 
         # AirStationConfig must not be specified in settings.toml
         'longitude': "",


### PR DESCRIPTION
This commit introduces a new `LOG_LEVEL` setting in the `settings.toml` files, allowing users to specify the minimum log level for the logger. The default log level is set to `DEBUG`. The logger implementation has been updated to utilize this configuration, ensuring that log messages are filtered according to the specified level. Documentation has also been updated to reflect this new setting.