### PR TITLE
Enhance deployment process and documentation for device settings

### DIFF
--- a/deploy/deploy.ipynb
+++ b/deploy/deploy.ipynb
@@ -23,15 +23,26 @@
         "\n",
         "Run the **setup** cell below, then **Serial port** to list USB devices and optionally pick one for **`CFG.serial_port`** (default **`/dev/tty.usbmodem101`**).\n",
         "\n",
-        "You can also edit **`CFG`** directly: `circuitpy_root`, `settings_slot` (for Step 3), and optional **`circuitpython_bin`** / **`circuitpython_board_id`** / **`circuitpython_locale`** / **`circuitpython_download_fallback_url`**."
+        "You can also edit **`CFG`** directly: `circuitpy_root`, and optional **`circuitpython_bin`** / **`circuitpython_board_id`** / **`circuitpython_locale`** / **`circuitpython_download_fallback_url`**`. Settings backups use **`device_id`** from the device `settings.toml` under **`deploy/settings_backups/<device_id>/`**."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "id": "f982205f",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeployConfig(serial_port='/dev/tty.usbmodem101', circuitpy_root=PosixPath('/Volumes/CIRCUITPY'), circuitpython_bin=PosixPath('/Users/silvioheinze/coding/firmware/deploy/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE.bin'), circuitpython_board_id='espressif_esp32s3_devkitc_1_n8r8', circuitpython_locale='de_DE', circuitpython_download_fallback_url='https://downloads.circuitpython.org/bin/espressif_esp32s3_devkitc_1_n8r8/en_GB/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-en_GB-10.1.4.bin', do_erase_flash=True, do_write_firmware=True, wait_for_circuitpy_mount=True, wait_timeout_s=120.0, poll_interval_s=1.0, do_copy_firmware_tree=True, full_flash_settings=PosixPath('/Users/silvioheinze/coding/firmware/deploy/settings.toml'))"
+            ]
+          },
+          "execution_count": 9,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "import sys\n",
         "from pathlib import Path\n",
@@ -73,7 +84,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 47,
+      "execution_count": 10,
       "id": "672724af",
       "metadata": {},
       "outputs": [
@@ -81,16 +92,21 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
+            "Available serial ports:\n",
+            "  1) /dev/cu.debug-console — 'n/a'\n",
+            "  2) /dev/cu.Bluetooth-Incoming-Port — 'n/a'\n",
+            "  3) /dev/cu.BoseQuietControl30 — 'n/a'\n",
+            "  4) /dev/cu.usbmodem8DB3AD34BD0B1 — 'ESP32-S3-DevKitC-1-N8R8'\n",
             "Using serial_port: /dev/cu.usbmodem8DB3AD34BD0B1\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "DeployConfig(serial_port='/dev/cu.usbmodem8DB3AD34BD0B1', circuitpy_root=PosixPath('/Volumes/CIRCUITPY'), circuitpython_bin=PosixPath('/Users/silvioheinze/coding/firmware/deploy/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE-10.1.4.bin'), circuitpython_board_id='espressif_esp32s3_devkitc_1_n8r8', circuitpython_locale='de_DE', circuitpython_download_fallback_url='https://downloads.circuitpython.org/bin/espressif_esp32s3_devkitc_1_n8r8/de_DE/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE-10.1.4.bin', settings_slot=0, do_erase_flash=True, do_write_firmware=True, wait_for_circuitpy_mount=True, wait_timeout_s=120.0, poll_interval_s=1.0, do_copy_firmware_tree=True, full_flash_settings=PosixPath('/Users/silvioheinze/coding/firmware/deploy/settings.toml'))"
+              "DeployConfig(serial_port='/dev/cu.usbmodem8DB3AD34BD0B1', circuitpy_root=PosixPath('/Volumes/CIRCUITPY'), circuitpython_bin=PosixPath('/Users/silvioheinze/coding/firmware/deploy/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE.bin'), circuitpython_board_id='espressif_esp32s3_devkitc_1_n8r8', circuitpython_locale='de_DE', circuitpython_download_fallback_url='https://downloads.circuitpython.org/bin/espressif_esp32s3_devkitc_1_n8r8/en_GB/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-en_GB-10.1.4.bin', do_erase_flash=True, do_write_firmware=True, wait_for_circuitpy_mount=True, wait_timeout_s=120.0, poll_interval_s=1.0, do_copy_firmware_tree=True, full_flash_settings=PosixPath('/Users/silvioheinze/coding/firmware/deploy/settings.toml'))"
             ]
           },
-          "execution_count": 47,
+          "execution_count": 10,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -131,45 +147,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 48,
+      "execution_count": null,
       "id": "dc070969",
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "$ /Users/silvioheinze/coding/firmware/.venv/bin/python -m esptool --port /dev/cu.usbmodem8DB3AD34BD0B1 erase_flash\n",
-            "Warning: Deprecated: Command 'erase_flash' is deprecated. Use 'erase-flash' instead.\n",
-            "esptool v5.2.0\n",
-            "Serial port /dev/cu.usbmodem8DB3AD34BD0B1:\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "A fatal error occurred: Could not open /dev/cu.usbmodem8DB3AD34BD0B1, the port is busy or doesn't exist.\n",
-            "([Errno 16] could not open port /dev/cu.usbmodem8DB3AD34BD0B1: [Errno 16] Resource busy: '/dev/cu.usbmodem8DB3AD34BD0B1')\n",
-            "\n"
-          ]
-        },
-        {
-          "ename": "CalledProcessError",
-          "evalue": "Command '['/Users/silvioheinze/coding/firmware/.venv/bin/python', '-m', 'esptool', '--port', '/dev/cu.usbmodem8DB3AD34BD0B1', 'erase_flash']' returned non-zero exit status 2.",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-            "\u001b[31mCalledProcessError\u001b[39m                        Traceback (most recent call last)",
-            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[48]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m flash_with_esptool(CFG)\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/coding/firmware/deploy/utils.py:295\u001b[39m, in \u001b[36mflash_with_esptool\u001b[39m\u001b[34m(cfg)\u001b[39m\n\u001b[32m    292\u001b[39m     \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo files to copy under \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msrc\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m, flush=\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[32m    293\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m295\u001b[39m tqdm_cls = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    296\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m show_progress \u001b[38;5;129;01mand\u001b[39;00m use_progress_bar:\n\u001b[32m    297\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/coding/firmware/deploy/utils.py:205\u001b[39m, in \u001b[36mrun_esptool\u001b[39m\u001b[34m(args, check)\u001b[39m\n\u001b[32m    203\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mrun_esptool\u001b[39m(args: \u001b[38;5;28mlist\u001b[39m[\u001b[38;5;28mstr\u001b[39m], *, check: \u001b[38;5;28mbool\u001b[39m = \u001b[38;5;28;01mTrue\u001b[39;00m) -> subprocess.CompletedProcess[\u001b[38;5;28mstr\u001b[39m]:\n\u001b[32m    204\u001b[39m     cmd = [sys.executable, \u001b[33m\"\u001b[39m\u001b[33m-m\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mesptool\u001b[39m\u001b[33m\"\u001b[39m] + args\n\u001b[32m--> \u001b[39m\u001b[32m205\u001b[39m     \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33m$\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33m \u001b[39m\u001b[33m\"\u001b[39m.join(cmd), flush=\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[32m    206\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m subprocess.run(cmd, check=check, text=\u001b[38;5;28;01mTrue\u001b[39;00m)\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/subprocess.py:577\u001b[39m, in \u001b[36mrun\u001b[39m\u001b[34m(input, capture_output, timeout, check, *popenargs, **kwargs)\u001b[39m\n\u001b[32m    575\u001b[39m     retcode = process.poll()\n\u001b[32m    576\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m check \u001b[38;5;129;01mand\u001b[39;00m retcode:\n\u001b[32m--> \u001b[39m\u001b[32m577\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m CalledProcessError(retcode, process.args,\n\u001b[32m    578\u001b[39m                                  output=stdout, stderr=stderr)\n\u001b[32m    579\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m CompletedProcess(process.args, retcode, stdout, stderr)\n",
-            "\u001b[31mCalledProcessError\u001b[39m: Command '['/Users/silvioheinze/coding/firmware/.venv/bin/python', '-m', 'esptool', '--port', '/dev/cu.usbmodem8DB3AD34BD0B1', 'erase_flash']' returned non-zero exit status 2."
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "flash_with_esptool(CFG)"
       ]
@@ -190,10 +171,41 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "id": "bc22bbe0",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Found: /Volumes/CIRCUITPY\n",
+            "Firmware copy: 208 files -> /Volumes/CIRCUITPY\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "d033cb8a022449e08f419ecb10a09ddf",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Firmware copy:   0%|          | 0/208 [00:00<?, ?file/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Copied firmware tree /Users/silvioheinze/coding/firmware/firmware -> /Volumes/CIRCUITPY (208 files)\n",
+            "Copied /Users/silvioheinze/coding/firmware/deploy/settings.toml -> /Volumes/CIRCUITPY/settings.toml\n"
+          ]
+        }
+      ],
       "source": [
         "copy_firmware_to_circuitpy(CFG)"
       ]
@@ -205,7 +217,7 @@
       "source": [
         "## Step 3 — Update firmware (existing board)\n",
         "\n",
-        "For a board **already in use**: refresh the **`firmware/`** tree from the repo while keeping WiFi and other settings via **`settings_slot`** and **`deploy/settings_backups/slot_N/`**. **`CIRCUITPY`** must already be mounted. **No** esptool.\n",
+        "For a board **already in use**: refresh the **`firmware/`** tree from the repo while keeping WiFi and other settings; backups go under **`deploy/settings_backups/<device_id>/`** (from `device_id` in `settings.toml`). **`CIRCUITPY`** must already be mounted. **No** esptool.\n",
         "\n",
         "The firmware tree copy uses the same **tqdm progress bar** as Step 2. After the copy, any **new keys** present in the repo’s **`firmware/settings.toml`** and **`firmware/startup.toml`** on **`CIRCUITPY`** but missing from your backed-up copies (when those backups exist) are merged into the slot backup the same way; then the merged files are written back to the board.\n",
         "\n",

--- a/deploy/readme.md
+++ b/deploy/readme.md
@@ -65,7 +65,7 @@ The notebook is organized as **three steps**: (1) **flash the board** (`flash_wi
 | `notebook_env.py` | Shared **`activate()`** so setup and serial cells find **`deploy/`** after a kernel restart |
 | `utils.py` | Esptool wrapper, mount wait, tree copy, full flash / update |
 | `settings.toml` | Copied to the device on **full flash** |
-| `settings_backups/slot_0/` … `slot_2/` | Each holds a `settings.toml` stash for **update only** (one logical device per slot) |
+| `settings_backups/<device_id>/` | Per-device stash of `settings.toml` / `startup.toml` (folder name from `device_id` in TOML; `unknown` if missing) |
 | `bin/*.bin` | Board CircuitPython image for esptool (auto-downloaded or manual; `*.bin` gitignored, folder kept with `.gitkeep`) |
 
 ## Deployment notes
@@ -96,6 +96,6 @@ This flow copies the whole [`../firmware/`](../firmware/) tree. For day-to-day l
 ## Pipelines
 
 - **Step 1 — Flash the board**: `flash_with_esptool` — esptool only; **`ensure_circuitpython_bin`** resolves a `.bin` (file at `circuitpython_bin`, newest in `deploy/bin/`, index, or **`circuitpython_download_fallback_url`**).
-- **Step 2 — Copy firmware to a new board**: `copy_firmware_to_circuitpy` — wait for `CIRCUITPY`, copy repo `firmware/` + `deploy/settings.toml`.
-- **Step 3 — Update firmware (existing board)**: `run_update_only` — backup device `settings.toml` (and `startup.toml` if present) to `settings_backups/slot_N/`, copy `firmware/`, merge any **new keys** from the repo `firmware/settings.toml` and `firmware/startup.toml` on `CIRCUITPY` into those backups when a backup file exists, then restore merged files to the board; **`settings_slot`** must be `0`, `1`, or `2`.
+- **Step 2 — Copy firmware to a new board**: `copy_firmware_to_circuitpy` — wait for `CIRCUITPY`, copy repo `firmware/`. If the device already has **`settings.toml`**, it is copied first to **`settings_backups/<device_id>/`**, then after the tree copy the same files are **restored** onto CIRCUITPY (the repo backup copy stays on disk). If there is **no** `settings.toml` yet, **`deploy/settings.toml`** is installed (new board).
+- **Step 3 — Update firmware (existing board)**: `run_update_only` — requires **`CIRCUITPY/settings.toml`**. Backs it up (and `startup.toml` if present) under **`settings_backups/<device_id>/`**, copies `firmware/`, merges any **new keys** from the repo templates on CIRCUITPY into those backup files, then restores merged files to the board.
 - **Shortcut**: `run_full_flash` = Step 1 + Step 2 (not Step 3).

--- a/deploy/utils.py
+++ b/deploy/utils.py
@@ -17,7 +17,9 @@ from typing import Iterable
 from urllib.parse import urljoin, urlparse
 
 DEPLOY_DIR = Path(__file__).resolve().parent
+# Per-device folders: ``settings_backups/<device_id>/`` (``device_id`` from TOML).
 SETTINGS_BACKUPS_DIR = DEPLOY_DIR / "settings_backups"
+UNKNOWN_DEVICE_BACKUP = "unknown"
 BIN_DIR = DEPLOY_DIR / "bin"
 
 # Used when directory index cannot be parsed (CDN errors, HTML changes).
@@ -185,7 +187,6 @@ class DeployConfig:
     circuitpython_board_id: str = "espressif_esp32s3_devkitc_1_n8r8"
     circuitpython_locale: str = "de_DE"
     circuitpython_download_fallback_url: str | None = DEFAULT_CIRCUITPYTHON_FALLBACK_URL
-    settings_slot: int = 0
     do_erase_flash: bool = True
     do_write_firmware: bool = True
     wait_for_circuitpy_mount: bool = True
@@ -193,10 +194,6 @@ class DeployConfig:
     poll_interval_s: float = 1.0
     do_copy_firmware_tree: bool = True
     full_flash_settings: Path = field(default_factory=lambda: DEPLOY_DIR / "settings.toml")
-
-    def __post_init__(self) -> None:
-        if self.settings_slot not in (0, 1, 2):
-            raise ValueError("settings_slot must be 0, 1, or 2")
 
 
 def run_esptool(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -337,26 +334,82 @@ def copy_file(src: Path, dst: Path) -> None:
     print(f"Copied {src} -> {dst}", flush=True)
 
 
-def settings_backup_dir(cfg: DeployConfig) -> Path:
-    return SETTINGS_BACKUPS_DIR / f"slot_{cfg.settings_slot}"
+def sanitize_settings_backup_folder_name(device_id: str) -> str:
+    """Safe single path segment for ``settings_backups/<here>/``."""
+    s = "".join(
+        c if (c.isalnum() or c in "-._") else "_"
+        for c in (device_id or "").strip()
+    ).strip("_")
+    if not s:
+        return UNKNOWN_DEVICE_BACKUP
+    return s[:128]
 
 
-def backup_settings_from_device(cfg: DeployConfig) -> None:
+def read_device_id_from_settings_toml(path: Path) -> str | None:
+    """Return ``device_id`` from a ``settings.toml`` file, or ``None`` if missing / unreadable."""
+    if not path.is_file():
+        return None
+    try:
+        import tomli
+
+        data = tomli.loads(path.read_text(encoding="utf-8"))
+        val = data.get("device_id")
+        if val is None:
+            return None
+        s = str(val).strip()
+        return s if s else None
+    except Exception:
+        pass
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    m = re.search(r'^\s*device_id\s*=\s*"([^"]*)"', text, re.MULTILINE)
+    if m:
+        s = m.group(1).strip()
+        return s if s else None
+    m = re.search(r"^\s*device_id\s*=\s*'([^']*)'", text, re.MULTILINE)
+    if m:
+        s = m.group(1).strip()
+        return s if s else None
+    return None
+
+
+def settings_backup_dir_for_device_id(device_id: str) -> Path:
+    return SETTINGS_BACKUPS_DIR / sanitize_settings_backup_folder_name(device_id)
+
+
+def backup_settings_from_device(cfg: DeployConfig) -> Path | None:
+    """
+    Copy ``settings.toml`` (and ``startup.toml`` if present) from CIRCUITPY into
+    ``settings_backups/<device_id>/``. Returns the backup directory, or ``None`` if
+    there is no ``settings.toml`` on the device.
+    """
     src = cfg.circuitpy_root / "settings.toml"
-    dest_dir = settings_backup_dir(cfg)
+    if not src.is_file():
+        return None
+    raw_id = read_device_id_from_settings_toml(src)
+    folder_key = raw_id if raw_id else UNKNOWN_DEVICE_BACKUP
+    if not raw_id:
+        print(
+            f"Warning: no device_id in {src}; using backup folder {UNKNOWN_DEVICE_BACKUP!r}.",
+            flush=True,
+        )
+    dest_dir = settings_backup_dir_for_device_id(folder_key)
     dest_dir.mkdir(parents=True, exist_ok=True)
     copy_file(src, dest_dir / "settings.toml")
     startup_src = cfg.circuitpy_root / "startup.toml"
     if startup_src.is_file():
         copy_file(startup_src, dest_dir / "startup.toml")
+    return dest_dir
 
 
-def restore_settings_backup(cfg: DeployConfig) -> None:
-    src = settings_backup_dir(cfg) / "settings.toml"
+def restore_settings_backup(cfg: DeployConfig, backup_dir: Path) -> None:
+    src = backup_dir / "settings.toml"
     if not src.is_file():
         raise FileNotFoundError(src)
     copy_file(src, cfg.circuitpy_root / "settings.toml")
-    startup_backup = settings_backup_dir(cfg) / "startup.toml"
+    startup_backup = backup_dir / "startup.toml"
     if startup_backup.is_file():
         copy_file(startup_backup, cfg.circuitpy_root / "startup.toml")
 
@@ -445,19 +498,19 @@ def _merge_toml_template_into_backup(
     )
 
 
-def merge_repo_settings_into_backup(cfg: DeployConfig) -> None:
-    """After ``copy_firmware_tree``, merge repo ``settings.toml`` on CIRCUITPY into the slot backup."""
+def merge_repo_settings_into_backup(cfg: DeployConfig, backup_dir: Path) -> None:
+    """After ``copy_firmware_tree``, merge repo ``settings.toml`` on CIRCUITPY into the device backup."""
     _merge_toml_template_into_backup(
-        settings_backup_dir(cfg) / "settings.toml",
+        backup_dir / "settings.toml",
         cfg.circuitpy_root / "settings.toml",
         "Settings",
     )
 
 
-def merge_repo_startup_into_backup(cfg: DeployConfig) -> None:
-    """Merge repo ``startup.toml`` on CIRCUITPY into slot backup (same rules as settings)."""
+def merge_repo_startup_into_backup(cfg: DeployConfig, backup_dir: Path) -> None:
+    """Merge repo ``startup.toml`` on CIRCUITPY into the device backup (same rules as settings)."""
     _merge_toml_template_into_backup(
-        settings_backup_dir(cfg) / "startup.toml",
+        backup_dir / "startup.toml",
         cfg.circuitpy_root / "startup.toml",
         "Startup",
     )
@@ -485,16 +538,34 @@ def flash_with_esptool(cfg: DeployConfig) -> None:
 
 
 def copy_firmware_to_circuitpy(cfg: DeployConfig) -> None:
-    """Wait for the USB drive, copy repo `firmware/` onto it, apply full-flash `settings.toml`."""
+    """Wait for the USB drive, copy repo ``firmware/`` onto it, then restore device settings.
+
+    If ``CIRCUITPY/settings.toml`` exists before the copy, it is copied first to
+    ``deploy/settings_backups/<device_id>/`` (subfolder from ``device_id`` in that file),
+    the firmware tree is copied, then the backed-up ``settings.toml`` / ``startup.toml``
+    are copied back onto CIRCUITPY (backup files remain under ``settings_backups/``).
+
+    If there is no ``settings.toml`` on the device yet, ``deploy/settings.toml`` is
+    installed (same as a blank new board).
+    """
     if cfg.wait_for_circuitpy_mount:
         wait_for_path(
             cfg.circuitpy_root,
             timeout_s=cfg.wait_timeout_s,
             interval_s=cfg.poll_interval_s,
         )
+    backup_dir = backup_settings_from_device(cfg)
+
     if cfg.do_copy_firmware_tree:
         copy_firmware_tree(firmware_src(), cfg.circuitpy_root)
-        deploy_full_flash_settings(cfg)
+        if backup_dir is not None:
+            restore_settings_backup(cfg, backup_dir)
+            print(
+                f"Restored device settings from {backup_dir} (copy also kept there).",
+                flush=True,
+            )
+        else:
+            deploy_full_flash_settings(cfg)
 
 
 def run_full_flash(cfg: DeployConfig) -> None:
@@ -508,11 +579,16 @@ def run_update_only(cfg: DeployConfig) -> None:
         raise FileNotFoundError(
             f"CIRCUITPY not mounted: {cfg.circuitpy_root} — adjust circuitpy_root or connect USB."
         )
-    backup_settings_from_device(cfg)
+    backup_dir = backup_settings_from_device(cfg)
+    if backup_dir is None:
+        raise FileNotFoundError(
+            f"No {cfg.circuitpy_root / 'settings.toml'} — use copy_firmware_to_circuitpy / "
+            "full flash for a new board, or create settings.toml on the device first."
+        )
     copy_firmware_tree(firmware_src(), cfg.circuitpy_root)
-    merge_repo_settings_into_backup(cfg)
-    merge_repo_startup_into_backup(cfg)
-    restore_settings_backup(cfg)
+    merge_repo_settings_into_backup(cfg, backup_dir)
+    merge_repo_startup_into_backup(cfg, backup_dir)
+    restore_settings_backup(cfg, backup_dir)
     print("Update finished.", flush=True)
 
 

--- a/docs/api-json.md
+++ b/docs/api-json.md
@@ -45,7 +45,7 @@ Most payloads are built from [`get_info()`](../firmware/models/ld_product_model.
 }
 ```
 
-- **`time`**: ISO-8601 string from [`format_iso8601_tz()`](../firmware/tz_format.py): `…Z` when `TZ` is UTC (or `GMT` / `Etc/UTC`), otherwise local civil time for **`Europe/Vienna`** (default if `TZ` is unset) with suffix **`+01:00`** or **`+02:00`** (EU DST). Based on `time.time()`; RTC should be **UTC** after NTP (`tz_offset=0`). See [`docs/settings.md`](settings.md) (`TZ`).
+- **`time`**: ISO-8601 string from [`format_iso8601_tz()`](../firmware/tz_format.py): `…Z` when `TZ` is UTC (or `GMT` / `Etc/UTC`), otherwise local civil time for **`Europe/Vienna`** (default if `TZ` is unset) with suffix **`+01:00`** or **`+02:00`** (EU DST). Datahub accepts these offset forms (e.g. `+02:00`) as well as `Z`. Based on `time.time()`; RTC should be **UTC** after NTP. See [`docs/settings.md`](settings.md) (`TZ`).
 - **`model`**: [`LdProduct`](../firmware/enums.py) integer (e.g. Air Station = 3).
 - **`sensors`**: Empty object here; filled in [`get_json()`](../firmware/models/ld_product_model.py).
 

--- a/docs/ble-characteristics.md
+++ b/docs/ble-characteristics.md
@@ -1,0 +1,173 @@
+# Bluetooth GATT: Luftdaten custom service
+
+This document describes the **single custom BLE service** and its characteristics as implemented in [`firmware/ld_service.py`](../firmware/ld_service.py), how [`firmware/main.py`](../firmware/main.py) fills read characteristics, and how writes on the command characteristic are interpreted.
+
+**Timezone:** There is **no** GATT characteristic and **no** Air Station configuration flag for **`TZ`** / IANA timezone. Timezone for API/log strings is configured in **`settings.toml`** only (see [`docs/settings.md`](settings.md)). To expose `TZ` over BLE in the future you would need a new `AirstationConfigFlags` value and matching app support.
+
+---
+
+## Service
+
+| Item | Value |
+|------|--------|
+| Python class | [`LdService`](../firmware/ld_service.py) |
+| Base class | `adafruit_ble.services.Service` |
+| **128-bit service UUID** | `0931b4b5-2917-4a8d-9e72-23103c09ac29` (Adafruit `VendorUUID`) |
+
+Advertising uses `ProvideServicesAdvertisement(service)` in [`main.py`](../firmware/main.py). The BLE name is `Luftdaten.at-` + `Config.settings['mac']`.
+
+---
+
+## Characteristics (overview)
+
+All characteristics use **vendor UUIDs** (same namespace as the service). `max_length` is **512** where defined in code.
+
+| Python attribute | UUID | Properties | Purpose |
+|------------------|------|------------|---------|
+| `air_station_configuration` | `b47b0cdf-0ced-49a9-86a5-d78a03ea7674` | READ | **Air Station:** TLV blob built by [`AirStation.encode_configurations()`](../firmware/models/air_station.py). Other models: initial `bytes([0])` (not updated in code paths shown). |
+| `sensor_values_characteristic` | `4b439140-73cb-4776-b1f2-8f3711b3bb4f` | READ | Binary concatenation of each sensor’s [`Sensor.get_current_values()`](../firmware/sensors/sensor.py) (see [Sensor values binary](#sensor-values-binary)). Updated in [`LdProductModel.update_ble_sensor_data()`](../firmware/models/ld_product_model.py). |
+| `device_info_characteristic` | `8d473240-13cb-1776-b1f2-823711b3ffff` | READ | **JSON** (UTF-8) when `api_key` is set at boot; else **legacy binary** (see [Device info](#device-info-characteristic)). Built in [`main.py`](../firmware/main.py). |
+| `device_status_characteristic` | `77db81d9-9773-49b4-aa17-16a2f93e95f2` | READ | Four bytes: battery flag, SOC %, voltage×10, error code ([`update_ble_battery_status`](../firmware/models/ld_product_model.py)). |
+| `sensor_info_characteristic` | `13fa8751-57af-4597-a0bb-b202f6111ae6` | READ | Concatenation of each sensor’s [`get_device_info()`](../firmware/sensors/sensor.py). If no sensors: `bytes([0x06])`. |
+| `trigger_reading_characteristic_2` | `030ff8b1-1e45-4ae6-bf36-3bca4c38cdba` | WRITE, WRITE_NO_RESPONSE | **Command input:** first byte is [`BleCommands`](#ble-commands). Payload is read once per loop in [`main.py`](../firmware/main.py), then cleared. |
+
+---
+
+## Write path: `trigger_reading_characteristic_2`
+
+After each connection poll, if the characteristic has been written, [`main.py`](../firmware/main.py) copies the value to `command`, clears the characteristic, then calls:
+
+1. `device.receive_command(command)` — model-specific (sensors, Air Station config).
+2. `device.status_led.receive_command(command)` — LED / brightness ([`LedController`](../firmware/led_controller.py)).
+
+Both receive the **same** byte buffer.
+
+### `BleCommands` ([`enums.py`](../firmware/enums.py))
+
+| Value (hex) | Name | Handled by |
+|-------------|------|------------|
+| `0x01` | `READ_SENSOR_DATA` | Air aRound / Bike, Air Badge, Air Cube ([`receive_command`](../firmware/models/air_cube.py) etc.); triggers sensor read + BLE updates. |
+| `0x02` | `READ_SENSOR_DATA_AND_BATTERY_STATUS` | Same models; also updates battery/status bytes. |
+| `0x03` | `UPDATE_BRIGHTNESS` | [`LedController.receive_command`](../firmware/led_controller.py): second byte is brightness level index `0…4`. |
+| `0x04` | `TURN_OFF_STATUS_LIGHT` | LED controller. |
+| `0x05` | `TURN_ON_STATUS_LIGHT` | LED controller. |
+| `0x06` | `SET_AIR_STATION_CONFIGURATION` | [`AirStation.receive_command`](../firmware/models/air_station.py): payload after `0x06` is TLV data (next section). |
+
+Air Station does not implement `READ_SENSOR_DATA` in `receive_command`; only `SET_AIR_STATION_CONFIGURATION` is handled there.
+
+### Air Station configuration TLV (`0x06`)
+
+After the leading `0x06`, the payload is a sequence of records:
+
+```text
+[ flag: u8 ][ length: u8 ][ value: length bytes ]  (repeated)
+```
+
+- **String settings:** `value` is UTF-8; `length` is `len(value_bytes)`.
+- **Integer settings:** `value` is **4 bytes** big-endian signed 32-bit (`struct.pack('>i', …)`); `length` is `4`.
+
+[`AirstationConfigFlags`](../firmware/enums.py) (`flag` value → meaning):
+
+| Flag | Name | `Config.settings` key | Value type |
+|------|------|----------------------|------------|
+| `0` | `AUTO_UPDATE_MODE` | `auto_update_mode` | int32 |
+| `1` | `BATTERY_SAVE_MODE` | `battery_save_mode` | int32 |
+| `2` | `MEASUREMENT_INTERVAL` | `measurement_interval` | int32 |
+| `3` | `LONGITUDE` | `longitude` | UTF-8 string |
+| `4` | `LATITUDE` | `latitude` | UTF-8 string |
+| `5` | `HEIGHT` | `height` | UTF-8 string |
+| `6` | `SSID` | `SSID` | UTF-8 string (triggers `WifiUtil.connect()` if changed) |
+| `7` | `PASSWORD` | `PASSWORD` | UTF-8 string (same) |
+| `8` | `DEVICE_ID` | — | Present in [`encode_configurations`](../firmware/models/air_station.py) for **read** TLV; **not** written in [`decode_configuration`](../firmware/models/air_station.py) (read-only over the wire from central’s perspective). |
+
+**Read-back:** [`AirStation.send_configuration`](../firmware/models/air_station.py) assigns `air_station_configuration` from `encode_configurations()`, which includes flags `0…5` and `8` (`DEVICE_ID`), **not** SSID/password (secrets are not mirrored on the read characteristic).
+
+---
+
+## Read path: binary layouts
+
+### Sensor values binary
+
+From [`Sensor.get_current_values`](../firmware/sensors/sensor.py) per sensor, concatenated in bus order:
+
+1. `model_id` — `u8`
+2. `len(current_values)` — `u8`
+3. For each dimension key in `current_values`:
+   - dimension id — `u8`
+   - value — **2 bytes** big-endian int16 = `round(physical_value * 10)`, or `0x00 0x00` if NaN / missing
+
+### Sensor info binary
+
+From [`Sensor.get_device_info`](../firmware/sensors/sensor.py):
+
+1. `model_id` — `u8`
+2. `len(measures_values)` — `u8`
+3. `measures_values` bytes
+4. `0xff` separator
+5. `sensor_details` bytes
+6. `0xff` terminator
+
+Multiple sensors are concatenated without an extra header (count is implied by advertising / main setup).
+
+### `device_info_characteristic`
+
+**A) JSON path** — when `Config.settings['api_key']` is truthy at boot ([`main.py`](../firmware/main.py)):
+
+- UTF-8 encoding of `json.dumps(device_info_json)`.
+- `device_info_json` = `device.get_info()` plus `sensor_list` (model id, dimension list, serial per sensor).
+
+The `device` object in JSON comes from [`LdProductModel.get_info()`](../firmware/models/ld_product_model.py): `time`, `device`, `firmware`, `model`, `apikey`, `source`, `test_mode`, `calibration_mode` — **not** `TZ`, `LOG_LEVEL`, or Wi‑Fi SSID.
+
+**B) Binary path** — when `api_key` is missing (and on exception fallback):
+
+| Offset | Field |
+|--------|--------|
+| 0 | `PROTOCOL_VERSION` (`u8`) |
+| 1 | `FIRMWARE_MAJOR` (`u8`) |
+| 2 | `FIRMWARE_MINOR` (`u8`) |
+| 3 | `FIRMWARE_PATCH` (`u8`) |
+| 4–7 | Reserved (zeros); “device name” not implemented |
+| 8 | `MODEL` (`u8`, [`LdProduct`](../firmware/enums.py)) |
+| 9… | `connected_sensors_status` (see below) |
+| … | `api_key` length (`u8`, min(len, 255)) |
+| … | `api_key` bytes (up to 255) |
+
+**`connected_sensors_status`** ([`main.py`](../firmware/main.py)):
+
+- Byte 0: count of connected sensors `N`
+- Then `N` times: `[ sensor_model_id: u8 ][ 0x01: connected ]`
+
+### `device_status_characteristic`
+
+Four bytes (extended by error code in [`update_ble_error_status`](../firmware/models/ld_product_model.py)):
+
+| Index | Meaning |
+|-------|---------|
+| 0 | `1` = battery monitor present, `0` = absent |
+| 1 | Battery SOC % (rounded) |
+| 2 | Battery voltage × 10 (rounded) |
+| 3 | Error code (`0` = none) |
+
+### `air_station_configuration` (read)
+
+TLV format **same flag bytes as write**, but payload built only from non-secret fields in [`encode_configurations()`](../firmware/models/air_station.py) (flags 0–5 and 8 as in the table above).
+
+---
+
+## Not exposed over BLE (non-exhaustive)
+
+These `settings.toml` / runtime items are **not** part of the Air Station TLV protocol and **not** in the JSON `device` blob today, including:
+
+- **`TZ`** (timezone for [`format_iso8601_tz()`](../firmware/tz_format.py))
+- **`LOG_LEVEL`**
+- **`TEST_MODE`**, **`CALIBRATION_MODE`** (API/flags may change them; not BLE TLV)
+- **`WIFILESS_MODE`**, **`SD_LOG_PATH`**, **`ROLLBACK`**, etc.
+
+Configure them via **USB** (`settings.toml`) or extend the firmware protocol and mobile apps together.
+
+---
+
+## Related documentation
+
+- [`docs/settings.md`](settings.md) — persistent keys including `TZ`.
+- [`docs/api-json.md`](api-json.md) — HTTP JSON shapes (separate from BLE `device_info` JSON, though `get_info()` overlaps conceptually).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -63,7 +63,11 @@ Per-device and user-facing options: Wi‑Fi, model, keys, Air Station behaviour,
 | `WIFILESS_MODE` | boolean / string | **Air Station only:** if true, skip normal Wi‑Fi/API loop and log measurements to SD (see [`readme.md`](../firmware/readme.md)). String values `1` / `true` / `yes` (case-insensitive) are accepted. |
 | `SD_LOG_PATH` | string | **Air Station wifiless:** JSONL log path (default `/sd/measurements.jsonl`). |
 | `ROLLBACK` | boolean | Set by the upgrade path / `code.py` to force booting the previous firmware bundle after a failed update. |
-| `TZ` | string | Time zone for API and log timestamps. **Default:** `Europe/Vienna` if unset or empty. Recognised values: `UTC` / `GMT` / `Etc/UTC` / `Zulu` (case-insensitive) → timestamps end with `Z`; `Europe/Vienna` → EU DST rules, suffix `+01:00` or `+02:00`. Any other name falls back to Vienna. Requires `time.time()` / RTC to reflect **UTC** after NTP (`tz_offset=0`). |
+| `TZ` | string | Time zone for **API / log string** timestamps only (`format_iso8601_tz`). **Default:** `Europe/Vienna` if unset or empty. Recognised values: `UTC` / `GMT` / `Etc/UTC` / `Zulu` (case-insensitive) → suffix `Z`; `Europe/Vienna` → EU DST, suffix `+01:00` / `+02:00` (Datahub and related backends accept these numeric offsets, not only `Z`). The **RTC** after Wi‑Fi NTP is always set to **UTC** wall fields ([`WifiUtil.set_RTC()`](../firmware/wifi_client.py) uses `NTP.utc_ns`, not `NTP.datetime`, because the latter calls `time.localtime` and can shift fields on some ports). `time.time()` is therefore Unix UTC; `TZ` does not change the RTC. |
+
+### Air Station (Wi‑Fi) — when data is not transmitted
+
+In [`AirStation.tick()`](../firmware/models/air_station.py), measurements are only queued when **all** of the following hold: Wi‑Fi is connected, `runtime_settings['rtc_is_set']` is true (NTP after Wi‑Fi), and **`latitude`**, **`longitude`**, and **`height`** in `settings.toml` are each **non-empty** after stripping whitespace (so `"0"` is allowed for height). Otherwise the firmware logs **`DATA CANNOT BE TRANSMITTED, not all configurations have been made:`** followed by a semicolon-separated list of what is still missing (that warning is emitted again only when the set of blockers changes).
 
 ### `MODEL` values (`LdProduct`)
 
@@ -115,3 +119,4 @@ Not stored in `settings.toml` / `boot.toml`. Examples:
 
 - **One-shot boot flags** (RTC sync, model detect, SD upload, SD wipe): [`firmware/startup.toml`](../firmware/startup.toml) — separate from `settings.toml` / `boot.toml`; read by startup helpers, not `AutoSaveDict`.
 - **JSON shapes sent to APIs:** [`docs/api-json.md`](api-json.md).
+- **Bluetooth GATT (custom service, characteristics, Air Station TLV):** [`docs/ble-characteristics.md`](ble-characteristics.md). **`TZ`** is not configurable over BLE; use `settings.toml`.

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -6,7 +6,6 @@ import busio  # type: ignore
 import gc
 import neopixel  # type: ignore
 import traceback
-import sys
 import supervisor
 
 import adafruit_ds3231
@@ -309,6 +308,10 @@ if __name__ == '__main__':
     try:
         main()
     except Exception as e:
-        full_traceback = traceback.format_exception(*sys.exc_info())
+        try:
+            tb = traceback.format_exception(type(e), e, e.__traceback__)
+            full_traceback = "".join(tb)
+        except Exception:
+            full_traceback = str(e)
         logger.critical(f"{e}\n{full_traceback}")
         supervisor.reload()

--- a/firmware/models/air_station.py
+++ b/firmware/models/air_station.py
@@ -31,6 +31,9 @@ class AirStation(LdProductModel):
         self.device_id = Config.settings['device_id']
         self.api_key = Config.settings['api_key']
 
+        # Last blocker set we warned about (avoid spamming ``tick`` every 2s).
+        self._last_xmit_blockers_key = None
+
         # init status led
         self.status_led = LedController(
             status_led=neopixel.NeoPixel(
@@ -162,6 +165,29 @@ class AirStation(LdProductModel):
         pass
 
     @staticmethod
+    def _settings_toml_key_blank(key: str) -> bool:
+        """True if the value is missing or only whitespace (``height`` may be ``\"0\"``)."""
+        v = Config.settings.get(key)
+        if v is None:
+            return True
+        return not str(v).strip()
+
+    def _data_transmit_blockers(self) -> list[str]:
+        """Human-readable reasons Air Station Wi‑Fi mode will not enqueue measurements."""
+        reasons = []
+        if not WifiUtil.radio.connected:
+            reasons.append("WiFi not connected")
+        if not Config.runtime_settings.get("rtc_is_set"):
+            reasons.append("RTC not set (connect Wi‑Fi and wait for NTP)")
+        if self._settings_toml_key_blank("latitude"):
+            reasons.append("latitude unset or empty in settings.toml")
+        if self._settings_toml_key_blank("longitude"):
+            reasons.append("longitude unset or empty in settings.toml")
+        if self._settings_toml_key_blank("height"):
+            reasons.append("height unset or empty in settings.toml")
+        return reasons
+
+    @staticmethod
     def _api_location_dict():
         """Lat/lon/height as floats or ``None`` for the station API (never empty strings)."""
         def num(v):
@@ -282,8 +308,15 @@ class AirStation(LdProductModel):
         if not Config.runtime_settings['rtc_is_set'] and WifiUtil.radio.connected:
             WifiUtil.set_RTC()
 
-        if not WifiUtil.radio.connected or not Config.runtime_settings['rtc_is_set'] or not all([Config.settings['longitude'], Config.settings['latitude'], Config.settings['height']]):
-            logger.warning('DATA CANNOT BE TRANSMITTED, Not all configurations have been made')
+        blockers = self._data_transmit_blockers()
+        if blockers:
+            bkey = tuple(blockers)
+            if bkey != self._last_xmit_blockers_key:
+                self._last_xmit_blockers_key = bkey
+                logger.warning(
+                    "DATA CANNOT BE TRANSMITTED, not all configurations have been made: "
+                    + "; ".join(blockers)
+                )
             self.status_led.show_led({
                 'repeat_mode': RepeatMode.FOREVER,
                     'elements': [
@@ -292,6 +325,7 @@ class AirStation(LdProductModel):
                 ],
             })
         else:
+            self._last_xmit_blockers_key = None
             self.status_led.show_led({
                 'repeat_mode': RepeatMode.PERMANENT,
                 'color': Color.GREEN_LOW,

--- a/firmware/tz_format.py
+++ b/firmware/tz_format.py
@@ -106,6 +106,31 @@ def _utc_ymd_from_epoch(secs: int):
     return (y, m, d, h, mi, s)
 
 
+def _day_of_year_utc(y: int, mo: int, d: int) -> int:
+    """1-based day-of-year for a UTC calendar date."""
+    n = d
+    for mm in range(1, mo):
+        n += _days_in_month(y, mm)
+    return n
+
+
+def utc_epoch_to_struct_time(secs: int) -> time.struct_time:
+    """
+    UTC ``time.struct_time`` from Unix epoch seconds (non-negative).
+
+    Use this for ``rtc.RTC().datetime`` after NTP: ``adafruit_ntp.NTP.datetime``
+    uses ``time.localtime(...)``, which can shift wall fields when the port
+    applies a non-zero local offset. ``NTP.utc_ns`` is true UTC.
+    """
+    parts = _utc_ymd_from_epoch(int(secs))
+    if parts is None:
+        return time.localtime(0)
+    y, mo, d, h, mi, s = parts
+    wday = _weekday_from_utc_date(y, mo, d)
+    yday = _day_of_year_utc(y, mo, d)
+    return time.struct_time((y, mo, d, h, mi, s, wday, yday, -1))
+
+
 def _vienna_offset_seconds(utc_epoch: int) -> int:
     """CET +3600 s, CEST +7200 s (EU rules)."""
     if utc_epoch < 0:

--- a/firmware/ugm/wifi_client.py
+++ b/firmware/ugm/wifi_client.py
@@ -87,15 +87,23 @@ class WifiUtil:
     @staticmethod
     def set_RTC():
         import rtc
+        import time
         from adafruit_ntp import NTP
 
         try:
             logger.debug('Trying to set RTC via NTP...')
             ntp = NTP(WifiUtil.pool, tz_offset=0, cache_seconds=3600)
-            rtc.RTC().datetime = ntp.datetime
+            utc_s = ntp.utc_ns // 1_000_000_000
+            if hasattr(time, "gmtime"):
+                rtc_st = time.gmtime(utc_s)
+            else:
+                from tz_format import utc_epoch_to_struct_time
+
+                rtc_st = utc_epoch_to_struct_time(utc_s)
+            rtc.RTC().datetime = rtc_st
             Config.runtime_settings['rtc_is_set'] = True  # Assuming rtc_is_set is a setting in your Config
 
-            logger.debug('RTC successfully configured')
+            logger.debug('RTC successfully configured (UTC from NTP utc_ns)')
 
             # set rtc module
             if rtc_module := Config.runtime_settings.get('rtc_module', None):

--- a/firmware/wifi_client.py
+++ b/firmware/wifi_client.py
@@ -1,4 +1,5 @@
 import gc
+import time
 from wifi import radio as wifi_radio
 from config import Config
 from enums import LdProduct
@@ -93,10 +94,23 @@ class WifiUtil:
         try:
             logger.debug('Trying to set RTC via NTP...')
             ntp = NTP(WifiUtil.pool, tz_offset=0, cache_seconds=3600)
-            rtc.RTC().datetime = ntp.datetime
+            # ``ntp.datetime`` uses ``time.localtime(utc_seconds)``, which is not UTC on
+            # some builds; ``utc_ns`` is true UTC (see Adafruit_CircuitPython_NTP).
+            utc_s = ntp.utc_ns // 1_000_000_000
+            if hasattr(time, "gmtime"):
+                rtc_st = time.gmtime(utc_s)
+            else:
+                from tz_format import utc_epoch_to_struct_time
+
+                rtc_st = utc_epoch_to_struct_time(utc_s)
+            rtc.RTC().datetime = rtc_st
             Config.runtime_settings['rtc_is_set'] = True  # Assuming rtc_is_set is a setting in your Config
 
-            logger.debug('RTC successfully configured')
+            logger.debug(
+                "RTC set from NTP (UTC): "
+                f"{rtc_st.tm_year:04d}-{rtc_st.tm_mon:02d}-{rtc_st.tm_mday:02d}T"
+                f"{rtc_st.tm_hour:02d}:{rtc_st.tm_min:02d}:{rtc_st.tm_sec:02d}Z epoch={utc_s}"
+            )
 
             # set rtc module
             if rtc_module := Config.runtime_settings.get('rtc_module', None):
@@ -222,19 +236,6 @@ class WifiUtil:
         )
 
     @staticmethod
-    def _debug_response_snippet(response, max_len: int = 160) -> str:
-        try:
-            t = response.text
-        except Exception:
-            return "(no body)"
-        if not t:
-            return "(empty)"
-        t = t.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
-        if len(t) > max_len:
-            return t[:max_len] + "…"
-        return t
-
-    @staticmethod
     def send_json_to_api(data, api_url: str = None, router: str = 'data/'):
         if not api_url:
             api_url = Config.runtime_settings['API_URL']
@@ -277,10 +278,8 @@ class WifiUtil:
             url=url_full,
             json=payload,
         )
-        logger.debug(
-            f"API POST done status={response.status_code} url={url_full} "
-            f"body={WifiUtil._debug_response_snippet(response)}"
-        )
+        # Do not read ``response.text`` / ``.content`` here: callers may use ``response.json()`` (adafruit_requests).
+        logger.debug(f"API POST done status={response.status_code} url={url_full}")
         # send to additional APIs
         # TODO: Handle response
         if Config.settings.get('API_URLS', None):
@@ -293,8 +292,7 @@ class WifiUtil:
                     json=payload,
                 )
                 logger.debug(
-                    f"API POST extra done status={extra_resp.status_code} url={extra_full} "
-                    f"body={WifiUtil._debug_response_snippet(extra_resp)}"
+                    f"API POST extra done status={extra_resp.status_code} url={extra_full}"
                 )
         return response
  
@@ -311,10 +309,7 @@ class WifiUtil:
             json=data,
             headers=header 
         )
-        logger.debug(
-            f"Sensor.Community done status={response.status_code} "
-            f"body={WifiUtil._debug_response_snippet(response)}"
-        )
+        logger.debug(f"Sensor.Community done status={response.status_code} url={url}")
         return response
 
 


### PR DESCRIPTION
This commit updates the deployment notebook to clarify the handling of device settings, including the introduction of per-device backup directories for `settings.toml` and `startup.toml`. The `backup_settings_from_device` function is improved to ensure settings are backed up correctly, and the restoration process is refined. Additionally, the documentation is updated to reflect these changes, including detailed descriptions of the deployment steps and the new structure for settings backups. The handling of time zones in the configuration is also clarified, ensuring consistent timestamp representation across the system.