### PR TITLE
Update deployment notebook and README to clarify firmware deployment steps

### DIFF
--- a/deploy/deploy.ipynb
+++ b/deploy/deploy.ipynb
@@ -11,7 +11,7 @@
         "\n",
         "**Firmware `.bin`**: store under **`deploy/bin/`** or rely on auto-download inside **`flash_with_esptool`** / **`run_full_flash`** (see readme).\n",
         "\n",
-        "Deployments are **Step 1–3** below; step code is **uncommented** so you can run each cell as needed. **Run all** will execute Step 1, then 2, then 3 in order (often wrong for one device: Step 3 is usually for **existing** boards only, not right after Step 2 on a new install). Run only the cells that match your task."
+        "Deployments are **Step 1** (serial flash) and **Step 2** (copy or update firmware on `CIRCUITPY`). Step 2 **chooses automatically**: if **`boot.toml`** already exists on the volume, it runs the **update** path (settings backup + merge + restore); otherwise it runs the **new-board** copy. **Run all** runs Step 1 then Step 2 — only run Step 1 when you need a full CircuitPython reflash.\n"
       ]
     },
     {
@@ -28,21 +28,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "id": "f982205f",
       "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "DeployConfig(serial_port='/dev/tty.usbmodem101', circuitpy_root=PosixPath('/Volumes/CIRCUITPY'), circuitpython_bin=PosixPath('/Users/silvioheinze/coding/firmware/deploy/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE.bin'), circuitpython_board_id='espressif_esp32s3_devkitc_1_n8r8', circuitpython_locale='de_DE', circuitpython_download_fallback_url='https://downloads.circuitpython.org/bin/espressif_esp32s3_devkitc_1_n8r8/en_GB/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-en_GB-10.1.4.bin', do_erase_flash=True, do_write_firmware=True, wait_for_circuitpy_mount=True, wait_timeout_s=120.0, poll_interval_s=1.0, do_copy_firmware_tree=True, full_flash_settings=PosixPath('/Users/silvioheinze/coding/firmware/deploy/settings.toml'))"
-            ]
-          },
-          "execution_count": 9,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import sys\n",
         "from pathlib import Path\n",
@@ -84,33 +73,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "id": "672724af",
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Available serial ports:\n",
-            "  1) /dev/cu.debug-console — 'n/a'\n",
-            "  2) /dev/cu.Bluetooth-Incoming-Port — 'n/a'\n",
-            "  3) /dev/cu.BoseQuietControl30 — 'n/a'\n",
-            "  4) /dev/cu.usbmodem8DB3AD34BD0B1 — 'ESP32-S3-DevKitC-1-N8R8'\n",
-            "Using serial_port: /dev/cu.usbmodem8DB3AD34BD0B1\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "DeployConfig(serial_port='/dev/cu.usbmodem8DB3AD34BD0B1', circuitpy_root=PosixPath('/Volumes/CIRCUITPY'), circuitpython_bin=PosixPath('/Users/silvioheinze/coding/firmware/deploy/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE.bin'), circuitpython_board_id='espressif_esp32s3_devkitc_1_n8r8', circuitpython_locale='de_DE', circuitpython_download_fallback_url='https://downloads.circuitpython.org/bin/espressif_esp32s3_devkitc_1_n8r8/en_GB/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-en_GB-10.1.4.bin', do_erase_flash=True, do_write_firmware=True, wait_for_circuitpy_mount=True, wait_timeout_s=120.0, poll_interval_s=1.0, do_copy_firmware_tree=True, full_flash_settings=PosixPath('/Users/silvioheinze/coding/firmware/deploy/settings.toml'))"
-            ]
-          },
-          "execution_count": 10,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import sys\n",
         "from pathlib import Path\n",
@@ -142,7 +108,7 @@
         "\n",
         "Serial flashing only (**`erase_flash`** if enabled, then **`write_flash`**). Resolves a **`.bin`** via **`ensure_circuitpython_bin`** (existing file, `deploy/bin/`, download index, or fallback). Does **not** copy the repo onto **`CIRCUITPY`**.\n",
         "\n",
-        "Use **BOOT + RESET** on ESP32-S3 if the port does not appear. After this step, reset the board and wait until **`CIRCUITPY`** mounts before Step 2."
+        "Use **BOOT + RESET** on ESP32-S3 if the port does not appear. After this step, reset the board and wait until **`CIRCUITPY`** mounts before Step 2 (copy or update)."
       ]
     },
     {
@@ -160,128 +126,30 @@
       "id": "bacbacc3",
       "metadata": {},
       "source": [
-        "## Step 2 — Copy firmware to a new board\n",
+        "## Step 2 — Copy or update firmware on CIRCUITPY\n",
         "\n",
-        "For a **new** board (or right after a full flash) when you want the repo **`firmware/`** tree plus **`deploy/settings.toml`** on **`CIRCUITPY`**. Waits for **`CFG.circuitpy_root`**, then copies.\n",
+        "Run the code cell below after **`CIRCUITPY`** is mounted (reset the board if needed).\n",
         "\n",
-        "While the **`firmware/`** tree is copied, the cell output shows a **tqdm progress bar** (per file, with the current path in the postfix). Install deps with **`uv sync`** at the repo root if the bar does not appear.\n",
+        "- **If `boot.toml` exists** on `CFG.circuitpy_root` → **update** (existing board): same as the former Step 3 — back up `settings.toml` / `startup.toml`, copy the repo **`firmware/`** tree, merge any **new keys** from repo templates into the slot backup, restore settings to the board.\n",
+        "- **If `boot.toml` is missing** → **new board** (same as the former Step 2): copy the **`firmware/`** tree plus **`deploy/settings.toml`** from this repo.\n",
         "\n",
-        "Do **not** run Step 3 on the same device in the same session unless you intend the backup/slot workflow (Step 3 overwrites the tree then restores slot settings)."
+        "While the **`firmware/`** tree is copied, output shows a **tqdm** progress bar (install deps with **`uv sync`** at the repo root if the bar does not appear).\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "id": "bc22bbe0",
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Found: /Volumes/CIRCUITPY\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Firmware copy: 208 files -> /Volumes/CIRCUITPY\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "89e3121cc941420c853b38b3b32924c1",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Firmware copy:   0%|          | 0/208 [00:00<?, ?file/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "ename": "KeyboardInterrupt",
-          "evalue": "",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-            "\u001b[31mKeyboardInterrupt\u001b[39m                         Traceback (most recent call last)",
-            "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[13]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m copy_firmware_to_circuitpy(CFG)\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/coding/firmware/deploy/utils.py:496\u001b[39m, in \u001b[36mcopy_firmware_to_circuitpy\u001b[39m\u001b[34m(cfg)\u001b[39m\n\u001b[32m    493\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(added) > \u001b[32m24\u001b[39m:\n\u001b[32m    494\u001b[39m     preview += \u001b[33m\"\u001b[39m\u001b[33m, …\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    495\u001b[39m \u001b[38;5;28mprint\u001b[39m(\n\u001b[32m--> \u001b[39m\u001b[32m496\u001b[39m     \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mlog_label\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m merge: added \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mlen\u001b[39m(added)\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m key(s) from repo template into backup: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mpreview\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m,\n\u001b[32m    497\u001b[39m     flush=\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[32m    498\u001b[39m )\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/coding/firmware/deploy/utils.py:308\u001b[39m, in \u001b[36mcopy_firmware_tree\u001b[39m\u001b[34m(src, dst, ignore_names, show_progress, use_progress_bar)\u001b[39m\n\u001b[32m    306\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    307\u001b[39m     rel = \u001b[38;5;28mstr\u001b[39m(sub.relative_to(src))\n\u001b[32m--> \u001b[39m\u001b[32m308\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m:\n\u001b[32m    309\u001b[39m     rel = sub.name\n\u001b[32m    310\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(rel) > \u001b[32m52\u001b[39m:\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/shutil.py:529\u001b[39m, in \u001b[36mcopy2\u001b[39m\u001b[34m(src, dst, follow_symlinks)\u001b[39m\n\u001b[32m    526\u001b[39m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    527\u001b[39m             \u001b[38;5;28;01mraise\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m529\u001b[39m \u001b[43mcopyfile\u001b[49m\u001b[43m(\u001b[49m\u001b[43msrc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdst\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfollow_symlinks\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfollow_symlinks\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    530\u001b[39m copystat(src, dst, follow_symlinks=follow_symlinks)\n\u001b[32m    531\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m dst\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/shutil.py:319\u001b[39m, in \u001b[36mcopyfile\u001b[39m\u001b[34m(src, dst, follow_symlinks)\u001b[39m\n\u001b[32m    317\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m _HAS_FCOPYFILE:\n\u001b[32m    318\u001b[39m     \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m319\u001b[39m         \u001b[43m_fastcopy_fcopyfile\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfsrc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfdst\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mposix\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_COPYFILE_DATA\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    320\u001b[39m         \u001b[38;5;28;01mreturn\u001b[39;00m dst\n\u001b[32m    321\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m _GiveupOnFastCopy:\n",
-            "\u001b[36mFile \u001b[39m\u001b[32m~/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/shutil.py:109\u001b[39m, in \u001b[36m_fastcopy_fcopyfile\u001b[39m\u001b[34m(fsrc, fdst, flags)\u001b[39m\n\u001b[32m    106\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m _GiveupOnFastCopy(err)  \u001b[38;5;66;03m# not a regular file\u001b[39;00m\n\u001b[32m    108\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m109\u001b[39m     \u001b[43mposix\u001b[49m\u001b[43m.\u001b[49m\u001b[43m_fcopyfile\u001b[49m\u001b[43m(\u001b[49m\u001b[43minfd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43moutfd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mflags\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    110\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mOSError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m    111\u001b[39m     err.filename = fsrc.name\n",
-            "\u001b[31mKeyboardInterrupt\u001b[39m: "
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
-        "copy_firmware_to_circuitpy(CFG)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a8e172ff",
-      "metadata": {},
-      "source": [
-        "## Step 3 — Update firmware (existing board)\n",
-        "\n",
-        "For a board **already in use**: refresh the **`firmware/`** tree from the repo while keeping WiFi and other settings; backups go under **`deploy/settings_backups/<device_id>/`** (from `device_id` in `settings.toml`). **`CIRCUITPY`** must already be mounted. **No** esptool.\n",
-        "\n",
-        "The firmware tree copy uses the same **tqdm progress bar** as Step 2. After the copy, any **new keys** present in the repo’s **`firmware/settings.toml`** and **`firmware/startup.toml`** on **`CIRCUITPY`** but missing from your backed-up copies (when those backups exist) are merged into the slot backup the same way; then the merged files are written back to the board.\n",
-        "\n",
-        "Skip Steps 1–2 when you only need an application update."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "id": "c6435405",
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Copied /Volumes/CIRCUITPY/settings.toml -> /Users/silvioheinze/coding/firmware/deploy/settings_backups/slot_0/settings.toml\n",
-            "Copied /Volumes/CIRCUITPY/startup.toml -> /Users/silvioheinze/coding/firmware/deploy/settings_backups/slot_0/startup.toml\n",
-            "Firmware copy: 208 files -> /Volumes/CIRCUITPY\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "f874cdeccba1440db5a522be2ad6626d",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Firmware copy:   0%|          | 0/208 [00:00<?, ?file/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Copied firmware tree /Users/silvioheinze/coding/firmware/firmware -> /Volumes/CIRCUITPY (208 files)\n",
-            "Settings merge: no new keys in repo template (backup unchanged).\n",
-            "Startup merge: no new keys in repo template (backup unchanged).\n",
-            "Copied /Users/silvioheinze/coding/firmware/deploy/settings_backups/slot_0/settings.toml -> /Volumes/CIRCUITPY/settings.toml\n",
-            "Copied /Users/silvioheinze/coding/firmware/deploy/settings_backups/slot_0/startup.toml -> /Volumes/CIRCUITPY/startup.toml\n",
-            "Update finished.\n"
-          ]
-        }
-      ],
-      "source": [
-        "run_update_only(CFG)"
+        "_boot = CFG.circuitpy_root / \"boot.toml\"\n",
+        "if _boot.is_file():\n",
+        "    print(f\"Found {_boot} — updating firmware (existing board).\", flush=True)\n",
+        "    run_update_only(CFG)\n",
+        "else:\n",
+        "    print(f\"No {_boot} — copying firmware tree (new board).\", flush=True)\n",
+        "    copy_firmware_to_circuitpy(CFG)\n"
       ]
     },
     {
@@ -311,7 +179,7 @@
       "source": [
         "## Optional — Shortcut for a new board\n",
         "\n",
-        "**`run_full_flash(CFG)`** runs **Step 1** then **Step 2** in one call (not Step 3). Use this **instead** of running the Step 1 and Step 2 cells above; leave the next line commented if you already use those cells, or you will flash twice."
+        "**`run_full_flash(CFG)`** runs **Step 1** then **`copy_firmware_to_circuitpy`** (equivalent to the **no `boot.toml`** branch of Step 2). Use this **instead** of running the Step 1 and Step 2 cells above; leave the next line commented if you already use those cells, or you will flash twice.\n"
       ]
     },
     {

--- a/deploy/readme.md
+++ b/deploy/readme.md
@@ -61,7 +61,7 @@ The notebook is organized as **three steps**: (1) **flash the board** (`flash_wi
 | Path | Purpose |
 |------|---------|
 | [`../pyproject.toml`](../pyproject.toml) (repo root) | Declares dependencies for **`uv sync`**; venv lives at **`<repo>/.venv`** |
-| `deploy.ipynb` | Notebook — config, Step 1 flash / Step 2 new board / Step 3 update |
+| `deploy.ipynb` | Notebook — config, Step 1 flash, Step 2 copy-or-update (uses `boot.toml` on `CIRCUITPY` to choose) |
 | `notebook_env.py` | Shared **`activate()`** so setup and serial cells find **`deploy/`** after a kernel restart |
 | `utils.py` | Esptool wrapper, mount wait, tree copy, full flash / update |
 | `settings.toml` | Copied to the device on **full flash** |
@@ -96,6 +96,5 @@ This flow copies the whole [`../firmware/`](../firmware/) tree. For day-to-day l
 ## Pipelines
 
 - **Step 1 — Flash the board**: `flash_with_esptool` — esptool only; **`ensure_circuitpython_bin`** resolves a `.bin` (file at `circuitpython_bin`, newest in `deploy/bin/`, index, or **`circuitpython_download_fallback_url`**).
-- **Step 2 — Copy firmware to a new board**: `copy_firmware_to_circuitpy` — wait for `CIRCUITPY`, copy repo `firmware/`. If the device already has **`settings.toml`**, it is copied first to **`settings_backups/<device_id>/`**, then after the tree copy the same files are **restored** onto CIRCUITPY (the repo backup copy stays on disk). If there is **no** `settings.toml` yet, **`deploy/settings.toml`** is installed (new board).
-- **Step 3 — Update firmware (existing board)**: `run_update_only` — requires **`CIRCUITPY/settings.toml`**. Backs it up (and `startup.toml` if present) under **`settings_backups/<device_id>/`**, copies `firmware/`, merges any **new keys** from the repo templates on CIRCUITPY into those backup files, then restores merged files to the board.
-- **Shortcut**: `run_full_flash` = Step 1 + Step 2 (not Step 3).
+- **Step 2 — Copy or update firmware** (single notebook cell): if **`boot.toml`** exists on **`CIRCUITPY`**, runs **`run_update_only`** (existing board — backup `settings.toml` / `startup.toml`, copy `firmware/`, merge new keys from repo templates into the slot backup, restore). If **`boot.toml`** is missing, runs **`copy_firmware_to_circuitpy`** (new board — copy `firmware/` plus **`deploy/settings.toml`**; see `utils.py` for restore behaviour when `settings.toml` already exists).
+- **Shortcut**: `run_full_flash` = Step 1 + **`copy_firmware_to_circuitpy`** (same as the “no `boot.toml`” path after a fresh flash).


### PR DESCRIPTION
This commit revises the deployment notebook to enhance the clarity of the firmware deployment process, specifically detailing the distinction between copying and updating firmware based on the presence of `boot.toml` on `CIRCUITPY`. The README is also updated to reflect these changes, ensuring users understand the new workflow for Step 2, which now encompasses both copying and updating firmware. Additionally, unnecessary output cells have been removed from the notebook to streamline the user experience.