### PR TITLE
Refactor deployment tools and update firmware handling

### DIFF
--- a/tools/deploy.ipynb
+++ b/tools/deploy.ipynb
@@ -23,15 +23,26 @@
         "\n",
         "Run the **setup** cell below, then **Serial port** to list USB devices and optionally pick one for **`CFG.serial_port`** (default **`/dev/tty.usbmodem101`**).\n",
         "\n",
-        "You can also edit **`CFG`** directly: `circuitpy_root`, and optional **`circuitpython_bin`** / **`circuitpython_board_id`** / **`circuitpython_locale`** / **`circuitpython_download_fallback_url`**`. Settings backups use **`device_id`** from the device `settings.toml` under **`deploy/settings_backups/<device_id>/`**."
+        "You can also edit **`CFG`** directly: `circuitpy_root`, and optional **`circuitpython_bin`** / **`circuitpython_board_id`** / **`circuitpython_locale`** / **`circuitpython_download_fallback_url`**`. Settings backups use **`device_id`** from the device `settings.toml` under **`tools/settings_backups/<device_id>/`**."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "id": "f982205f",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "DeployConfig(serial_port='/dev/tty.usbmodem101', circuitpy_root=PosixPath('/Volumes/CIRCUITPY'), circuitpython_bin=PosixPath('/Users/silvioheinze/coding/firmware/tools/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE.bin'), circuitpython_board_id='espressif_esp32s3_devkitc_1_n8r8', circuitpython_locale='de_DE', circuitpython_download_fallback_url='https://downloads.circuitpython.org/bin/espressif_esp32s3_devkitc_1_n8r8/en_GB/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-en_GB-10.1.4.bin', do_erase_flash=True, do_write_firmware=True, wait_for_circuitpy_mount=True, wait_timeout_s=120.0, poll_interval_s=1.0, do_copy_firmware_tree=True)"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "import sys\n",
         "from pathlib import Path\n",
@@ -48,12 +59,12 @@
         "\n",
         "from utils import (\n",
         "    DeployConfig,\n",
-        "    copy_firmware_to_circuitpy,\n",
+        "    copy_firmware_full,\n",
         "    flash_with_esptool,\n",
         "    list_serial_ports,\n",
         "    pick_serial_port_interactive,\n",
         "    run_full_flash,\n",
-        "    run_update_only,\n",
+        "    copy_firmware_update,\n",
         ")\n",
         "\n",
         "# Override defaults, e.g. DeployConfig(circuitpy_root=Path(\"/media/youruser/CIRCUITPY\"))  # Linux CIRCUITPY path\n",
@@ -73,10 +84,33 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "id": "672724af",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Available serial ports:\n",
+            "  1) /dev/cu.debug-console — 'n/a'\n",
+            "  2) /dev/cu.Bluetooth-Incoming-Port — 'n/a'\n",
+            "  3) /dev/cu.BoseQuietControl30 — 'n/a'\n",
+            "  4) /dev/cu.usbmodem2101 — 'USB JTAG/serial debug unit'\n",
+            "Using serial_port: /dev/cu.usbmodem2101\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "DeployConfig(serial_port='/dev/cu.usbmodem2101', circuitpy_root=PosixPath('/Volumes/CIRCUITPY'), circuitpython_bin=PosixPath('/Users/silvioheinze/coding/firmware/tools/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-de_DE.bin'), circuitpython_board_id='espressif_esp32s3_devkitc_1_n8r8', circuitpython_locale='de_DE', circuitpython_download_fallback_url='https://downloads.circuitpython.org/bin/espressif_esp32s3_devkitc_1_n8r8/en_GB/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-en_GB-10.1.4.bin', do_erase_flash=True, do_write_firmware=True, wait_for_circuitpy_mount=True, wait_timeout_s=120.0, poll_interval_s=1.0, do_copy_firmware_tree=True)"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "import sys\n",
         "from pathlib import Path\n",
@@ -113,10 +147,143 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "id": "dc070969",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "$ /Users/silvioheinze/coding/firmware/.venv/bin/python -m esptool --port /dev/cu.usbmodem2101 erase_flash\n",
+            "Warning: Deprecated: Command 'erase_flash' is deprecated. Use 'erase-flash' instead.\n",
+            "esptool v5.2.0\n",
+            "Serial port /dev/cu.usbmodem2101:\n",
+            "Connecting...\n",
+            "Detecting chip type... ESP32-S3\n",
+            "Connected to ESP32-S3 on /dev/cu.usbmodem2101:\n",
+            "Chip type:          ESP32-S3 (QFN56) (revision v0.2)\n",
+            "Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz, Embedded PSRAM 8MB (AP_3v3)\n",
+            "Crystal frequency:  40MHz\n",
+            "USB mode:           USB-Serial/JTAG\n",
+            "MAC:                d8:3b:da:43:db:e4\n",
+            "\n",
+            "Uploading stub flasher...\n",
+            "Running stub flasher...\n",
+            "Stub flasher running.\n",
+            "\n",
+            "Erasing flash memory (this may take a while)...\n",
+            "Flash memory erased successfully in 3.3 seconds.\n",
+            "\n",
+            "Hard resetting via RTS pin...\n",
+            "$ /Users/silvioheinze/coding/firmware/.venv/bin/python -m esptool --port /dev/cu.usbmodem2101 write_flash -z 0x0 /Users/silvioheinze/coding/firmware/tools/bin/adafruit-circuitpython-espressif_esp32s3_devkitc_1_n8r8-en_GB-10.1.4.bin\n",
+            "Warning: Deprecated: Command 'write_flash' is deprecated. Use 'write-flash' instead.\n",
+            "esptool v5.2.0\n",
+            "Serial port /dev/cu.usbmodem2101:\n",
+            "Connecting...\n",
+            "Detecting chip type... ESP32-S3\n",
+            "Connected to ESP32-S3 on /dev/cu.usbmodem2101:\n",
+            "Chip type:          ESP32-S3 (QFN56) (revision v0.2)\n",
+            "Features:           Wi-Fi, BT 5 (LE), Dual Core + LP Core, 240MHz, Embedded PSRAM 8MB (AP_3v3)\n",
+            "Crystal frequency:  40MHz\n",
+            "USB mode:           USB-Serial/JTAG\n",
+            "MAC:                d8:3b:da:43:db:e4\n",
+            "\n",
+            "Uploading stub flasher...\n",
+            "Running stub flasher...\n",
+            "Stub flasher running.\n",
+            "\n",
+            "Configuring flash size...\n",
+            "Flash will be erased from 0x00000000 to 0x001d0fff...\n",
+            "Compressed 1901280 bytes to 1267994...\n",
+            "Writing at 0x00000000 [                              ]   0.0% 0/1267994 bytes... \n",
+            "Writing at 0x000134b4 [                              ]   1.3% 16384/1267994 bytes... \n",
+            "Writing at 0x0001b479 [                              ]   2.6% 32768/1267994 bytes... \n",
+            "Writing at 0x00021bca [>                             ]   3.9% 49152/1267994 bytes... \n",
+            "Writing at 0x00027f8c [>                             ]   5.2% 65536/1267994 bytes... \n",
+            "Writing at 0x00031601 [>                             ]   6.5% 81920/1267994 bytes... \n",
+            "Writing at 0x0003bc15 [=>                            ]   7.8% 98304/1267994 bytes... \n",
+            "Writing at 0x00042c47 [=>                            ]   9.0% 114688/1267994 bytes... \n",
+            "Writing at 0x00047ac6 [==>                           ]  10.3% 131072/1267994 bytes... \n",
+            "Writing at 0x0004cda8 [==>                           ]  11.6% 147456/1267994 bytes... \n",
+            "Writing at 0x000538df [==>                           ]  12.9% 163840/1267994 bytes... \n",
+            "Writing at 0x0005ce73 [===>                          ]  14.2% 180224/1267994 bytes... \n",
+            "Writing at 0x00062699 [===>                          ]  15.5% 196608/1267994 bytes... \n",
+            "Writing at 0x000679d7 [====>                         ]  16.8% 212992/1267994 bytes... \n",
+            "Writing at 0x0006d01b [====>                         ]  18.1% 229376/1267994 bytes... \n",
+            "Writing at 0x0007231a [====>                         ]  19.4% 245760/1267994 bytes... \n",
+            "Writing at 0x000777b1 [=====>                        ]  20.7% 262144/1267994 bytes... \n",
+            "Writing at 0x0007cb10 [=====>                        ]  22.0% 278528/1267994 bytes... \n",
+            "Writing at 0x00081ea8 [=====>                        ]  23.3% 294912/1267994 bytes... \n",
+            "Writing at 0x00087370 [======>                       ]  24.6% 311296/1267994 bytes... \n",
+            "Writing at 0x0008c8f7 [======>                       ]  25.8% 327680/1267994 bytes... \n",
+            "Writing at 0x000927e8 [=======>                      ]  27.1% 344064/1267994 bytes... \n",
+            "Writing at 0x00097ca5 [=======>                      ]  28.4% 360448/1267994 bytes... \n",
+            "Writing at 0x0009d557 [=======>                      ]  29.7% 376832/1267994 bytes... \n",
+            "Writing at 0x000a3031 [========>                     ]  31.0% 393216/1267994 bytes... \n",
+            "Writing at 0x000a98cf [========>                     ]  32.3% 409600/1267994 bytes... \n",
+            "Writing at 0x000aff7f [=========>                    ]  33.6% 425984/1267994 bytes... \n",
+            "Writing at 0x000b4fc9 [=========>                    ]  34.9% 442368/1267994 bytes... \n",
+            "Writing at 0x000ba230 [=========>                    ]  36.2% 458752/1267994 bytes... \n",
+            "Writing at 0x000bf76b [==========>                   ]  37.5% 475136/1267994 bytes... \n",
+            "Writing at 0x000c46e7 [==========>                   ]  38.8% 491520/1267994 bytes... \n",
+            "Writing at 0x000c95a9 [===========>                  ]  40.1% 507904/1267994 bytes... \n",
+            "Writing at 0x000cf736 [===========>                  ]  41.3% 524288/1267994 bytes... \n",
+            "Writing at 0x000d5770 [===========>                  ]  42.6% 540672/1267994 bytes... \n",
+            "Writing at 0x000de8df [============>                 ]  43.9% 557056/1267994 bytes... \n",
+            "Writing at 0x000e434d [============>                 ]  45.2% 573440/1267994 bytes... \n",
+            "Writing at 0x000e9310 [============>                 ]  46.5% 589824/1267994 bytes... \n",
+            "Writing at 0x000ef200 [=============>                ]  47.8% 606208/1267994 bytes... \n",
+            "Writing at 0x000f4e28 [=============>                ]  49.1% 622592/1267994 bytes... \n",
+            "Writing at 0x000fb02a [==============>               ]  50.4% 638976/1267994 bytes... \n",
+            "Writing at 0x00100851 [==============>               ]  51.7% 655360/1267994 bytes... \n",
+            "Writing at 0x001059cc [==============>               ]  53.0% 671744/1267994 bytes... \n",
+            "Writing at 0x0010ae94 [===============>              ]  54.3% 688128/1267994 bytes... \n",
+            "Writing at 0x001102df [===============>              ]  55.6% 704512/1267994 bytes... \n",
+            "Writing at 0x00115628 [================>             ]  56.9% 720896/1267994 bytes... \n",
+            "Writing at 0x0011ab1f [================>             ]  58.1% 737280/1267994 bytes... \n",
+            "Writing at 0x0011fd97 [================>             ]  59.4% 753664/1267994 bytes... \n",
+            "Writing at 0x0012505d [=================>            ]  60.7% 770048/1267994 bytes... \n",
+            "Writing at 0x0012ae73 [=================>            ]  62.0% 786432/1267994 bytes... \n",
+            "Writing at 0x0013060b [=================>            ]  63.3% 802816/1267994 bytes... \n",
+            "Writing at 0x00136165 [==================>           ]  64.6% 819200/1267994 bytes... \n",
+            "Writing at 0x0013b980 [==================>           ]  65.9% 835584/1267994 bytes... \n",
+            "Writing at 0x00141c06 [===================>          ]  67.2% 851968/1267994 bytes... \n",
+            "Writing at 0x0014755c [===================>          ]  68.5% 868352/1267994 bytes... \n",
+            "Writing at 0x0014c78d [===================>          ]  69.8% 884736/1267994 bytes... \n",
+            "Writing at 0x0015189f [====================>         ]  71.1% 901120/1267994 bytes... \n",
+            "Writing at 0x00156d67 [====================>         ]  72.4% 917504/1267994 bytes... \n",
+            "Writing at 0x0015c5e9 [=====================>        ]  73.7% 933888/1267994 bytes... \n",
+            "Writing at 0x00161b75 [=====================>        ]  74.9% 950272/1267994 bytes... \n",
+            "Writing at 0x001671ec [=====================>        ]  76.2% 966656/1267994 bytes... \n",
+            "Writing at 0x0016cd71 [======================>       ]  77.5% 983040/1267994 bytes... \n",
+            "Writing at 0x00172af1 [======================>       ]  78.8% 999424/1267994 bytes... \n",
+            "Writing at 0x001782e0 [=======================>      ]  80.1% 1015808/1267994 bytes... \n",
+            "Writing at 0x0017dd0b [=======================>      ]  81.4% 1032192/1267994 bytes... \n",
+            "Writing at 0x001832e2 [=======================>      ]  82.7% 1048576/1267994 bytes... \n",
+            "Writing at 0x00188850 [========================>     ]  84.0% 1064960/1267994 bytes... \n",
+            "Writing at 0x0018dae7 [========================>     ]  85.3% 1081344/1267994 bytes... \n",
+            "Writing at 0x00192b15 [========================>     ]  86.6% 1097728/1267994 bytes... \n",
+            "Writing at 0x00197fae [=========================>    ]  87.9% 1114112/1267994 bytes... \n",
+            "Writing at 0x0019dd63 [=========================>    ]  89.2% 1130496/1267994 bytes... \n",
+            "Writing at 0x001a38fb [==========================>   ]  90.4% 1146880/1267994 bytes... \n",
+            "Writing at 0x001aa5e6 [==========================>   ]  91.7% 1163264/1267994 bytes... \n",
+            "Writing at 0x001afeb6 [==========================>   ]  93.0% 1179648/1267994 bytes... \n",
+            "Writing at 0x001b5c1f [===========================>  ]  94.3% 1196032/1267994 bytes... \n",
+            "Writing at 0x001bb2ac [===========================>  ]  95.6% 1212416/1267994 bytes... \n",
+            "Writing at 0x001c113a [============================> ]  96.9% 1228800/1267994 bytes... \n",
+            "Writing at 0x001c79ca [============================> ]  98.2% 1245184/1267994 bytes... \n",
+            "Writing at 0x001ccac9 [============================> ]  99.5% 1261568/1267994 bytes... \n",
+            "Writing at 0x001d02e0 [==============================] 100.0% 1267994/1267994 bytes... \n",
+            "Wrote 1901280 bytes (1267994 compressed) at 0x00000000 in 11.7 seconds (1302.6 kbit/s).\n",
+            "Verifying written data...\n",
+            "Hash of data verified.\n",
+            "\n",
+            "Hard resetting via RTS pin...\n",
+            "Reset the board if needed; after this, CIRCUITPY should mount for the copy step.\n"
+          ]
+        }
+      ],
       "source": [
         "flash_with_esptool(CFG)"
       ]
@@ -131,25 +298,57 @@
         "Run the code cell below after **`CIRCUITPY`** is mounted (reset the board if needed).\n",
         "\n",
         "- **If `boot.toml` exists** on `CFG.circuitpy_root` → **update** (existing board): same as the former Step 3 — back up `settings.toml` / `startup.toml`, copy the repo **`firmware/`** tree, merge any **new keys** from repo templates into the slot backup, restore settings to the board.\n",
-        "- **If `boot.toml` is missing** → **new board** (same as the former Step 2): copy the **`firmware/`** tree plus **`deploy/settings.toml`** from this repo.\n",
+        "- **If `boot.toml` is missing** → **new board** (same as the former Step 2): copy **`firmware/`**, copy **`tools/settings.toml`** onto the volume, then re-apply **values** parsed from any previous **`settings.toml`** (e.g. Wi‑Fi credentials). Does **not** use the **`settings_backups/`** snapshot flow (that stays on the update branch).\n",
         "\n",
         "While the **`firmware/`** tree is copied, output shows a **tqdm** progress bar (install deps with **`uv sync`** at the repo root if the bar does not appear).\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "id": "bc22bbe0",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "No /Volumes/CIRCUITPY/boot.toml — copying firmware tree (new board).\n",
+            "Found: /Volumes/CIRCUITPY\n",
+            "Firmware copy: 213 files -> /Volumes/CIRCUITPY\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "d2d7296e31644bcf9261ee991ef17d0a",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Firmware copy:   0%|          | 0/213 [00:00<?, ?file/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Copied firmware tree /Users/silvioheinze/coding/firmware/firmware -> /Volumes/CIRCUITPY (213 files)\n",
+            "Copied /Users/silvioheinze/coding/firmware/tools/settings.toml -> /Volumes/CIRCUITPY/settings.toml\n"
+          ]
+        }
+      ],
       "source": [
         "_boot = CFG.circuitpy_root / \"boot.toml\"\n",
         "if _boot.is_file():\n",
         "    print(f\"Found {_boot} — updating firmware (existing board).\", flush=True)\n",
-        "    run_update_only(CFG)\n",
+        "    copy_firmware_update(CFG)\n",
         "else:\n",
         "    print(f\"No {_boot} — copying firmware tree (new board).\", flush=True)\n",
-        "    copy_firmware_to_circuitpy(CFG)\n"
+        "    copy_firmware_full(CFG)\n"
       ]
     },
     {
@@ -179,7 +378,7 @@
       "source": [
         "## Optional — Shortcut for a new board\n",
         "\n",
-        "**`run_full_flash(CFG)`** runs **Step 1** then **`copy_firmware_to_circuitpy`** (equivalent to the **no `boot.toml`** branch of Step 2). Use this **instead** of running the Step 1 and Step 2 cells above; leave the next line commented if you already use those cells, or you will flash twice.\n"
+        "**`run_full_flash(CFG)`** runs **Step 1** then **`copy_firmware_full`** (equivalent to the **no `boot.toml`** branch of Step 2). Use this **instead** of running the Step 1 and Step 2 cells above; leave the next line commented if you already use those cells, or you will flash twice.\n"
       ]
     },
     {
@@ -195,13 +394,21 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
     "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
       "name": "python",
-      "pygments_lexer": "ipython3"
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.14.3"
     }
   },
   "nbformat": 4,

--- a/tools/readme.md
+++ b/tools/readme.md
@@ -44,7 +44,7 @@ jupyter notebook deploy/deploy.ipynb
 
 ### Workflow
 
-The notebook is organized as **three steps**: (1) **flash the board** (`flash_with_esptool`), (2) **copy firmware to a new board** (`copy_firmware_to_circuitpy` after `CIRCUITPY` mounts), (3) **update firmware on an existing board** (`run_update_only`). For a brand-new install you typically run 1 then 2; for an already-configured device run 3 only. **`run_full_flash`** is a shortcut for 1+2.
+The notebook is organized as **three steps**: (1) **flash the board** (`flash_with_esptool`), (2) **copy firmware to a new board** (`copy_firmware_full` after `CIRCUITPY` mounts), (3) **update firmware on an existing board** (`copy_firmware_update`). For a brand-new install you typically run 1 then 2; for an already-configured device run 3 only. **`run_full_flash`** is a shortcut for 1+2.
 
 1. Edit **`CFG`** in [`deploy.ipynb`](deploy.ipynb) if needed, then run the **Step 1–3** cells that match your task (they are ready to run; avoid **Run all** unless you intend the full sequence).
 
@@ -96,5 +96,5 @@ This flow copies the whole [`../firmware/`](../firmware/) tree. For day-to-day l
 ## Pipelines
 
 - **Step 1 — Flash the board**: `flash_with_esptool` — esptool only; **`ensure_circuitpython_bin`** resolves a `.bin` (file at `circuitpython_bin`, newest in `deploy/bin/`, index, or **`circuitpython_download_fallback_url`**).
-- **Step 2 — Copy or update firmware** (single notebook cell): if **`boot.toml`** exists on **`CIRCUITPY`**, runs **`run_update_only`** (existing board — backup `settings.toml` / `startup.toml`, copy `firmware/`, merge new keys from repo templates into the slot backup, restore). If **`boot.toml`** is missing, runs **`copy_firmware_to_circuitpy`** (new board — copy `firmware/` plus **`deploy/settings.toml`**; see `utils.py` for restore behaviour when `settings.toml` already exists).
-- **Shortcut**: `run_full_flash` = Step 1 + **`copy_firmware_to_circuitpy`** (same as the “no `boot.toml`” path after a fresh flash).
+- **Step 2 — Copy or update firmware** (single notebook cell): if **`boot.toml`** exists on **`CIRCUITPY`**, runs **`copy_firmware_update`** (existing board — backup `settings.toml` / `startup.toml`, copy `firmware/`, merge new keys from repo templates into the slot backup, restore). If **`boot.toml`** is missing, runs **`copy_firmware_full`** (new board — copy `firmware/`, install **`tools/settings.toml`**, then merge parsed **values** from any existing device `settings.toml` on top; no `settings_backups/` snapshot; `startup.toml` is still only handled on the update path).
+- **Shortcut**: `run_full_flash` = Step 1 + **`copy_firmware_full`** (same as the “no `boot.toml`” path after a fresh flash).

--- a/tools/settings.toml
+++ b/tools/settings.toml
@@ -1,5 +1,5 @@
 ROLLBACK = false
-MODEL = 1
+MODEL = 3
 TEST_MODE = false
 SSID = "luftdaten.at"
 PASSWORD = "clientpassword"

--- a/tools/settings_backups/unknown/startup.toml
+++ b/tools/settings_backups/unknown/startup.toml
@@ -1,0 +1,17 @@
+# One-shot startup actions (read at boot). Set a flag to true, reboot; on success the
+# firmware clears the flag. Wi-Fi credentials stay in settings.toml (SSID / PASSWORD).
+
+# When true: connect Wi-Fi once, set time from NTP to CircuitPython RTC and DS3231 (if present), then clear this flag.
+SYNC_RTC_FROM_NTP = false
+
+# When true: after scanning I2C sensors, set settings.toml MODEL from hardware and clear this flag.
+# Transitional: MODEL = -1 in settings.toml still triggers the same detect until you migrate to this flag only.
+DETECT_MODEL_FROM_SENSORS = false
+
+# Air Station wifiless only: after sensor scan, connect Wi-Fi and POST each line of SD_LOG_PATH (JSONL) to
+# the datahub data/ API; on full success truncate the log file and clear this flag. SSID required in settings.toml.
+UPLOAD_SD_LOG_TO_DATAHUB = false
+
+# Air Station wifiless only: after sensor scan (and after UPLOAD_SD_LOG_TO_DATAHUB if enabled), delete all files
+# and folders under /sd, then clear this flag. No Wi-Fi required. Destructive — use for a factory-style wipe.
+CLEAR_SD_CARD = false

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -19,6 +19,8 @@ from typing import Any, Iterable
 from urllib.parse import urljoin, urlparse
 
 DEPLOY_DIR = Path(__file__).resolve().parent
+# Default device settings installed by ``copy_firmware_full`` (after copying ``firmware/`` onto CIRCUITPY).
+TOOLS_SETTINGS_TOML = DEPLOY_DIR / "settings.toml"
 # Per-device folders: ``settings_backups/<device_id>/`` (``device_id`` from TOML).
 SETTINGS_BACKUPS_DIR = DEPLOY_DIR / "settings_backups"
 UNKNOWN_DEVICE_BACKUP = "unknown"
@@ -195,7 +197,6 @@ class DeployConfig:
     wait_timeout_s: float = 120.0
     poll_interval_s: float = 1.0
     do_copy_firmware_tree: bool = True
-    full_flash_settings: Path = field(default_factory=lambda: DEPLOY_DIR / "settings.toml")
 
 
 def run_esptool(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -427,6 +428,18 @@ def _merge_toml_add_missing_keys(old: dict, new: dict) -> dict:
     return merged
 
 
+def _deep_overlay_toml_dict(template: dict, overlay: dict) -> dict:
+    """Start from ``template``; for every key in ``overlay``, attach its value (recursive for dict pairs)."""
+
+    merged = copy.deepcopy(template)
+    for key, oval in overlay.items():
+        if isinstance(merged.get(key), dict) and isinstance(oval, dict):
+            merged[key] = _deep_overlay_toml_dict(merged[key], oval)
+        else:
+            merged[key] = copy.deepcopy(oval)
+    return merged
+
+
 def _list_toml_keys_added_by_merge(old: dict, new: dict, prefix: str = "") -> list[str]:
     """Human-readable paths for keys present in ``new`` but not in ``old`` (recursive)."""
     added: list[str] = []
@@ -519,9 +532,64 @@ def merge_repo_startup_into_backup(cfg: DeployConfig, backup_dir: Path) -> None:
 
 
 def deploy_full_flash_settings(cfg: DeployConfig) -> None:
-    if not cfg.full_flash_settings.is_file():
-        raise FileNotFoundError(cfg.full_flash_settings)
-    copy_file(cfg.full_flash_settings, cfg.circuitpy_root / "settings.toml")
+    if not TOOLS_SETTINGS_TOML.is_file():
+        raise FileNotFoundError(TOOLS_SETTINGS_TOML)
+    copy_file(TOOLS_SETTINGS_TOML, cfg.circuitpy_root / "settings.toml")
+
+
+def _read_settings_toml_dict(path: Path) -> dict[str, Any] | None:
+    """Parse ``settings.toml`` or return ``None`` on missing file / unreadable / parse failure."""
+    if not path.is_file():
+        return None
+    try:
+        import tomli
+
+        text = path.read_text(encoding="utf-8")
+        data = tomli.loads(text)
+    except ImportError:
+        print("tomli missing (run ``uv sync``); cannot read previous settings.toml.", flush=True)
+        return None
+    except OSError as ex:
+        print(f"Could not read {path}: {ex}; skipping preserved settings overlay.", flush=True)
+        return None
+    except Exception as ex:
+        print(f"Could not parse {path}: {ex}; skipping preserved settings overlay.", flush=True)
+        return None
+
+    return data if isinstance(data, dict) else None
+
+
+def _write_merged_settings_toml(dest: Path, template: Path, preserved: dict[str, Any]) -> None:
+    try:
+        import tomli
+        import tomli_w
+    except ImportError:
+        print(
+            "tomli/tomli-w missing (run ``uv sync``); keeping tools/settings.toml without overlay.",
+            flush=True,
+        )
+        return
+    try:
+        base_text = template.read_text(encoding="utf-8")
+        base = tomli.loads(base_text)
+    except Exception as ex:
+        print(f"Could not read template {template}: {ex}; skipping overlay.", flush=True)
+        return
+    merged = _deep_overlay_toml_dict(base, preserved)
+    if merged == base:
+        return
+    tmp = dest.with_suffix(".toml.merged.tmp")
+    try:
+        tmp.write_text(tomli_w.dumps(merged), encoding="utf-8")
+        tmp.replace(dest)
+    except Exception:
+        if tmp.is_file():
+            tmp.unlink(missing_ok=True)
+        raise
+    print(
+        "Merged saved values from the previous ``settings.toml`` onto ``tools/settings.toml``.",
+        flush=True,
+    )
 
 
 def flash_with_esptool(cfg: DeployConfig) -> None:
@@ -539,16 +607,14 @@ def flash_with_esptool(cfg: DeployConfig) -> None:
     )
 
 
-def copy_firmware_to_circuitpy(cfg: DeployConfig) -> None:
-    """Wait for the USB drive, copy repo ``firmware/`` onto it, then restore device settings.
+def copy_firmware_full(cfg: DeployConfig) -> None:
+    """Wait for the USB drive, copy repo ``firmware/`` onto it, install ``tools/settings.toml``, then
+    overlay values from any **previous** device ``settings.toml`` (Wi‑Fi and other keys), without
+    keeping the old file verbatim.
 
-    If ``CIRCUITPY/settings.toml`` exists before the copy, it is copied first to
-    ``deploy/settings_backups/<device_id>/`` (subfolder from ``device_id`` in that file),
-    the firmware tree is copied, then the backed-up ``settings.toml`` / ``startup.toml``
-    are copied back onto CIRCUITPY (backup files remain under ``settings_backups/``).
-
-    If there is no ``settings.toml`` on the device yet, ``deploy/settings.toml`` is
-    installed (same as a blank new board).
+    ``startup.toml`` is not preserved here (repo copy wins). Using TOML parse + write may drop
+    comments in ``settings.toml`` when merging. Use :func:`copy_firmware_update` when ``boot.toml``
+    exists to retain both files with backup-folder behaviour and different merge rules for new keys.
     """
     if cfg.wait_for_circuitpy_mount:
         wait_for_path(
@@ -556,27 +622,25 @@ def copy_firmware_to_circuitpy(cfg: DeployConfig) -> None:
             timeout_s=cfg.wait_timeout_s,
             interval_s=cfg.poll_interval_s,
         )
-    backup_dir = backup_settings_from_device(cfg)
+
+    device_settings = cfg.circuitpy_root / "settings.toml"
+    preserved_before_copy = _read_settings_toml_dict(device_settings)
 
     if cfg.do_copy_firmware_tree:
         copy_firmware_tree(firmware_src(), cfg.circuitpy_root)
-        if backup_dir is not None:
-            restore_settings_backup(cfg, backup_dir)
-            print(
-                f"Restored device settings from {backup_dir} (copy also kept there).",
-                flush=True,
-            )
-        else:
-            deploy_full_flash_settings(cfg)
+        deploy_full_flash_settings(cfg)
+        if preserved_before_copy:
+            dest = cfg.circuitpy_root / "settings.toml"
+            _write_merged_settings_toml(dest, TOOLS_SETTINGS_TOML, preserved_before_copy)
 
 
 def run_full_flash(cfg: DeployConfig) -> None:
     flash_with_esptool(cfg)
-    copy_firmware_to_circuitpy(cfg)
+    copy_firmware_full(cfg)
     print("Full flash finished.", flush=True)
 
 
-def run_update_only(cfg: DeployConfig) -> None:
+def copy_firmware_update(cfg: DeployConfig) -> None:
     if not cfg.circuitpy_root.is_dir():
         raise FileNotFoundError(
             f"CIRCUITPY not mounted: {cfg.circuitpy_root} — adjust circuitpy_root or connect USB."
@@ -584,7 +648,7 @@ def run_update_only(cfg: DeployConfig) -> None:
     backup_dir = backup_settings_from_device(cfg)
     if backup_dir is None:
         raise FileNotFoundError(
-            f"No {cfg.circuitpy_root / 'settings.toml'} — use copy_firmware_to_circuitpy / "
+            f"No {cfg.circuitpy_root / 'settings.toml'} — use copy_firmware_full / "
             "full flash for a new board, or create settings.toml on the device first."
         )
     copy_firmware_tree(firmware_src(), cfg.circuitpy_root)


### PR DESCRIPTION
This commit enhances the deployment process by renaming functions for clarity and updating the README to reflect changes in the firmware copying and updating workflow. The `copy_firmware_to_circuitpy` function is now `copy_firmware_full`, and `run_update_only` has been replaced with `copy_firmware_update`. Additionally, the settings structure is improved to support merging values from previous device settings, ensuring a smoother user experience during firmware deployment.