### PR TITLE
Update BLE characteristics and firmware to support new startup.toml flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,5 @@ firmware/test.py
 tools/bin/*.bin
 
 # backup files
-tools/settings_backups/slot_0/*
-tools/settings_backups/slot_1/*
-tools/settings_backups/slot_2/*
-
+tools/settings_backups/*
 tools/sd_from_device/*

--- a/docs/ble-characteristics.md
+++ b/docs/ble-characteristics.md
@@ -2,7 +2,7 @@
 
 This document describes the **single custom BLE service** and its characteristics as implemented in [`firmware/ld_service.py`](../firmware/ld_service.py), how [`firmware/main.py`](../firmware/main.py) fills read characteristics, and how writes on the command characteristic are interpreted.
 
-**Station-only TLV flags** (Air Station command **`0x06`**, read on **`air_station_configuration`**): **`18`** `TZ` (IANA timezone), **`19`** `LOG_LEVEL` (e.g. `DEBUG` / `INFO`), **`20`** `api_key` (UTF-8 Datahub/API token — **sensitive**; mask in UIs). These update `settings.toml` like other TLV string fields. **`0x07`** (Cube) stays **MQTT-only** (`9…17`).
+**Station-only TLV flags** (Air Station command **`0x06`**, read on **`air_station_configuration`**): **`18`** `TZ` (IANA timezone), **`19`** `LOG_LEVEL` (e.g. `DEBUG` / `INFO`), **`20`** `api_key` (UTF-8 Datahub/API token — **sensitive**; mask in UIs). These update `settings.toml` like other TLV string fields. **`21…25`** map to one-shot booleans in [`startup.toml`](../firmware/startup.toml) (not `Config` / `settings.toml`). **`0x07`** (Cube) stays **MQTT-only** (`9…17`).
 
 ---
 
@@ -92,8 +92,15 @@ After the leading `0x06`, the payload is a sequence of records:
 | `18` | `TZ` | `TZ` | UTF-8 string (IANA timezone name, e.g. `Europe/Vienna`; see [`docs/settings.md`](settings.md)) |
 | `19` | `LOG_LEVEL` | `LOG_LEVEL` | UTF-8 string (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`; unknown names behave like `DEBUG`; see [`docs/settings.md`](settings.md)) |
 | `20` | `API_KEY` | `api_key` | UTF-8 string (Datahub/API workshop token; **sensitive** — included in read-back TLV for apps) |
+| `21` | `SYNC_RTC_FROM_NTP` | `startup.toml` key **`SYNC_RTC_FROM_NTP`** | int32 (`0` → `false`, non-zero → `true`) |
+| `22` | `DETECT_MODEL_FROM_SENSORS` | **`DETECT_MODEL_FROM_SENSORS`** | int32 (same) |
+| `23` | `UPLOAD_SD_LOG_TO_DATAHUB` | **`UPLOAD_SD_LOG_TO_DATAHUB`** | int32 (same); **sensitive** (datahub upload from SD) |
+| `24` | `CLEAR_SD_CARD` | **`CLEAR_SD_CARD`** | int32 (same); **destructive** |
+| `25` | `REFRESH_SENSORS` | **`REFRESH_SENSORS`** | int32 (same) |
 
-**Read-back:** [`AirStation.send_configuration`](../firmware/models/air_station.py) assigns `air_station_configuration` from `encode_configurations()`, which includes flags `0…5`, **`18…20`**, `8` (`DEVICE_ID`), and **non-secret** MQTT fields `9…13`, `15`, `16`, and `17` when set — **not** SSID, Wi‑Fi password, or **`MQTT_PASSWORD`** (secrets are not mirrored on the read characteristic). **`api_key` (flag `20`)** is mirrored so companion apps can read it; treat like a credential on the wire.
+**`startup.toml` flags (`21…25`):** Writes update `/startup.toml` on CIRCUITPY (same semantics as editing the file over USB). **Boot timing:** [`main()`](../firmware/main.py) and [`run_startup_actions()`](../firmware/startup_actions.py) read these flags near the **start** of boot. A BLE write **during a running session** persists the flag for the **next reboot** — it does **not** re-run the corresponding startup helpers mid-loop. **Recommendation:** change the TLV, disconnect, then **reboot** (or cycle power). Read-back exposes the **current persisted** booleans (`0`/`1` int32) so apps can show pending one-shots. BLE is **unauthenticated** in this protocol; **`23`** and **`24`** are particularly sensitive.
+
+**Read-back:** [`AirStation.send_configuration`](../firmware/models/air_station.py) assigns `air_station_configuration` from `encode_configurations()`, which includes flags `0…5`, **`18…25`**, `8` (`DEVICE_ID`), and **non-secret** MQTT fields `9…13`, `15`, `16`, and `17` when set — **not** SSID, Wi‑Fi password, or **`MQTT_PASSWORD`** (secrets are not mirrored on the read characteristic). **`api_key` (flag `20`)** is mirrored so companion apps can read it; treat like a credential on the wire.
 
 **Air Cube MQTT TLV:** the same flag bytes and value encodings as in the table (`9…17`) are used after command byte **`0x07`**. There is **no** `air_station_configuration` read characteristic on the Cube; the app may keep local UI state after write. See [`docs/companion-app-mqtt-ble.md`](companion-app-mqtt-ble.md).
 

--- a/docs/companion-app-mqtt-ble.md
+++ b/docs/companion-app-mqtt-ble.md
@@ -27,7 +27,7 @@ After the **first command byte**, the payload is a sequence of records:
 
 | Model | First byte | Notes |
 |-------|------------|--------|
-| **Air Station** | `0x06` (`SET_AIR_STATION_CONFIGURATION`) | Wi‑Fi / geo (`0…8`), MQTT (`9…17`), **`TZ` (`18`)**, **`LOG_LEVEL` (`19`)**, **`api_key` (`20`)** — UTF-8 TLVs; **`0x07` not** used for these. |
+| **Air Station** | `0x06` (`SET_AIR_STATION_CONFIGURATION`) | Wi‑Fi / geo (`0…8`), MQTT (`9…17`), **`TZ` (`18`)**, **`LOG_LEVEL` (`19`)**, **`api_key` (`20`)**, **`startup.toml` one-shots (`21…25`)** — not MQTT; **`0x07` not** used for these. |
 | **Air Cube** | `0x07` (`SET_CUBE_MQTT_CONFIGURATION`) | **MQTT flags only** (`9…17`); same record layout as Station. |
 
 ## MQTT flags (`AirstationConfigFlags`)

--- a/firmware/enums.py
+++ b/firmware/enums.py
@@ -339,6 +339,12 @@ class AirstationConfigFlags:
     TZ = 18
     LOG_LEVEL = 19
     API_KEY = 20
+    # startup.toml one-shots — Air Station 0x06 TLV only (int32 0 / non-zero → false / true).
+    SYNC_RTC_FROM_NTP = 21
+    DETECT_MODEL_FROM_SENSORS = 22
+    UPLOAD_SD_LOG_TO_DATAHUB = 23
+    CLEAR_SD_CARD = 24
+    REFRESH_SENSORS = 25
 
 class AirStationMeasurementInterval:
     sec30 = 30

--- a/firmware/models/air_station.py
+++ b/firmware/models/air_station.py
@@ -12,6 +12,15 @@ from enums import LdProduct, Color, BleCommands, AirstationConfigFlags, Dimensio
 from logger import logger
 from led_controller import RepeatMode
 from sd_logger import append_measurement_jsonl
+from startup_actions import is_startup_flag_true, set_startup_flag
+
+_AIR_STATION_BLE_STARTUP_TOML = (
+    (AirstationConfigFlags.SYNC_RTC_FROM_NTP, "SYNC_RTC_FROM_NTP"),
+    (AirstationConfigFlags.DETECT_MODEL_FROM_SENSORS, "DETECT_MODEL_FROM_SENSORS"),
+    (AirstationConfigFlags.UPLOAD_SD_LOG_TO_DATAHUB, "UPLOAD_SD_LOG_TO_DATAHUB"),
+    (AirstationConfigFlags.CLEAR_SD_CARD, "CLEAR_SD_CARD"),
+    (AirstationConfigFlags.REFRESH_SENSORS, "REFRESH_SENSORS"),
+)
 
 class AirStation(LdProductModel):
     NEOPIXEL_PIN = board.IO8
@@ -149,6 +158,12 @@ class AirStation(LdProductModel):
             if flag == AirstationConfigFlags.API_KEY:
                 Config.settings['api_key'] = data[idx:idx + length].decode('utf-8')
 
+            for startup_flag, startup_key in _AIR_STATION_BLE_STARTUP_TOML:
+                if flag == startup_flag:
+                    if length == 4:
+                        v_raw = struct.unpack('>i', data[idx : idx + length])[0]
+                        set_startup_flag(startup_key, bool(v_raw))
+
             if (
                 AirstationConfigFlags.MQTT_ENABLED
                 <= flag
@@ -191,6 +206,11 @@ class AirStation(LdProductModel):
         if cert and str(cert).strip():
             mqtt_rows.append((AirstationConfigFlags.MQTT_CERTIFICATE_PATH, str(cert).strip()))
 
+        startup_rows = [
+            (flt, 1 if is_startup_flag_true(key) else 0)
+            for flt, key in _AIR_STATION_BLE_STARTUP_TOML
+        ]
+
         for flag, value in [
             (AirstationConfigFlags.AUTO_UPDATE_MODE, Config.settings['auto_update_mode']),
             (AirstationConfigFlags.BATTERY_SAVE_MODE, Config.settings['battery_save_mode']),
@@ -205,7 +225,7 @@ class AirStation(LdProductModel):
             ),
             (AirstationConfigFlags.API_KEY, str(Config.settings.get('api_key') or '')),
             (AirstationConfigFlags.DEVICE_ID, self.device_id),
-        ] + mqtt_rows:
+        ] + mqtt_rows + startup_rows:
             value_bytes = value.encode('utf-8') if isinstance(value, str) else struct.pack('>i', value)
             data.append(flag)
             data.append(len(value_bytes) if isinstance(value, str) else struct.calcsize('>i'))

--- a/firmware/startup_actions.py
+++ b/firmware/startup_actions.py
@@ -143,6 +143,16 @@ def clear_startup_flag(key: str) -> None:
         logger.error(f"Could not clear {STARTUP_TOML} flag {key!r}: {e}")
 
 
+def set_startup_flag(key: str, value: bool) -> None:
+    """Write a boolean startup.toml key (requires USB FS remount on CircuitPython)."""
+    try:
+        remount("/", False)
+        put(key, value, toml=STARTUP_TOML)
+        remount("/", True)
+    except OSError as e:
+        logger.error(f"Could not set {STARTUP_TOML} flag {key!r}={value!r}: {e}")
+
+
 def _append_datahub_upload_log(msg: str) -> None:
     """Append one line to ``DATAHUB_UPLOAD_LOG_PATH`` on CIRCUITPY root; never raises."""
     rw = False


### PR DESCRIPTION
This commit enhances the BLE configuration for the Air Station by adding support for new one-shot flags in `startup.toml`, including `SYNC_RTC_FROM_NTP`, `DETECT_MODEL_FROM_SENSORS`, `UPLOAD_SD_LOG_TO_DATAHUB`, `CLEAR_SD_CARD`, and `REFRESH_SENSORS`. The documentation has been updated to reflect these changes, ensuring clarity on the new features and their usage. Additionally, the `.gitignore` file has been modified to simplify backup file management.