### PR TITLE
Add SD log export functionality for wifiless Air Station

### DIFF
--- a/docs/ble-characteristics.md
+++ b/docs/ble-characteristics.md
@@ -30,6 +30,7 @@ All characteristics use **vendor UUIDs** (same namespace as the service). `max_l
 | `device_status_characteristic` | `77db81d9-9773-49b4-aa17-16a2f93e95f2` | READ | Four bytes: battery flag, SOC %, voltage×10, error code ([`update_ble_battery_status`](../firmware/models/ld_product_model.py)). |
 | `sensor_info_characteristic` | `13fa8751-57af-4597-a0bb-b202f6111ae6` | READ | Concatenation of each sensor’s [`get_device_info()`](../firmware/sensors/sensor.py). If no sensors: `bytes([0x06])`. |
 | `trigger_reading_characteristic_2` | `030ff8b1-1e45-4ae6-bf36-3bca4c38cdba` | WRITE, WRITE_NO_RESPONSE | **Command input:** first byte is [`BleCommands`](#ble-commands). Payload is read once per loop in [`main.py`](../firmware/main.py), then cleared. |
+| `sd_log_export_characteristic` | `51d2f8a4-91c6-53b2-a6e5-71829304a505` | READ | **Air Station wifiless:** Chunked lines from [`SD_LOG_PATH`](../firmware/sd_logger.py) JSONL ([`sd_ble_export`](../firmware/sd_ble_export.py)). Idle **READ** exposes non-empty bit; write **`0x08`** then READ to stream. |
 
 ---
 
@@ -52,9 +53,27 @@ Both receive the **same** byte buffer.
 | `0x04` | `TURN_OFF_STATUS_LIGHT` | LED controller. |
 | `0x05` | `TURN_ON_STATUS_LIGHT` | LED controller. |
 | `0x06` | `SET_AIR_STATION_CONFIGURATION` | [`AirStation.receive_command`](../firmware/models/air_station.py): payload after `0x06` is TLV data (next section). |
-| `0x07` | `SET_CUBE_MQTT_CONFIGURATION` | [`AirCube.receive_command`](../firmware/models/air_cube.py): payload after `0x07` is **MQTT-only** TLV records (flags `9…17` only; Station-only flags **`18…20`** / **`TZ`**, **`LOG_LEVEL`**, **`api_key`** use `0x06`). |
+| `0x07` | `SET_CUBE_MQTT_CONFIGURATION` | [`AirCube.receive_command`](../firmware/models/air_cube.py): payload after `0x07` is **MQTT-only** TLV records (flags `9…17` only; Station-only flags **`18…25`** use `0x06`). |
+| `0x08` | `SD_LOG_EXPORT` | [`AirStation.receive_command`](../firmware/models/air_station.py) **only** when **wifiless** ([`Config.is_air_station_wifiless()`](../firmware/config.py)): second byte is **`action`** — `0` START (open log from beginning), `1` NEXT (populate read chunk). Ignore on other models (no-op). |
 
-Air Station does not implement `READ_SENSOR_DATA` in `receive_command`; only `SET_AIR_STATION_CONFIGURATION` is handled there.
+Air Station does not implement `READ_SENSOR_DATA` in `receive_command`; Station handles `SET_AIR_STATION_CONFIGURATION` and **`SD_LOG_EXPORT`** (wifiless) as above.
+
+### SD JSONL log export (`0x08`)
+
+**Product / mode:** **Air Station** with **`WIFILESS_MODE`** only. Logs are appended by [`sd_logger.append_measurement_jsonl`](../firmware/sd_logger.py) to **`SD_LOG_PATH`** (default `/sd/measurements.jsonl`).
+
+**Companion flow:** while connected, **READ** `sd_log_export_characteristic` to see **`status`** **`0`** (idle) and **`flags`** bit **`0`** (`0x01`): set when the JSONL file exists on the mounted SD with **size &gt; 0** (so the app can show “data available” without sending **`0x08`**). To stream: write **`[0x08, 0]`** (START). Then repeat: write **`[0x08, 1]`** (NEXT), **READ** the characteristic, concatenate UTF-8 payload bytes until **`status`** is **`2`** (end of one JSON line), parse JSON. Continue until **`status`** **`3`** (EOF). During an active **`0x08`** transfer, **`status`** is not **`0`**; idle **`flags`** are only meaningful when **`status`** **`0`**.
+
+**Chunk frame (`sd_log_export_characteristic`, binary):**
+
+| Offset | Field | Description |
+|--------|--------|-------------|
+| 0 | `status` `u8` | `0` idle, `1` line fragment (more **`NEXT`** for same line), `2` completes one JSONL line, `3` EOF (file closed), `4` error |
+| 1 | `flags` `u8` | If **`status=0`** (idle): bit **`0`** (`0x01`) = JSONL exists and is non-empty; other bits reserved. If **`status=4`**: `1` not wifiless, `2` SD mount failed, `3` open failed/missing file, `4` read I/O failure, `5` **`NEXT`** without **`START`** |
+| 2–3 | `payload_len` `u16` BE | length of UTF-8 payload (`0–508`; whole value ≤512 bytes). |
+| 4… | payload | UTF-8 text |
+
+**Security:** unauthenticated BLE can dump logged measurements — protect in UI.
 
 ### Air Station configuration TLV (`0x06`)
 

--- a/docs/companion-app-mqtt-ble.md
+++ b/docs/companion-app-mqtt-ble.md
@@ -9,6 +9,7 @@ This document is for the **mobile app** (separate repository). It specifies how 
 | Service | `0931b4b5-2917-4a8d-9e72-23103c09ac29` |
 | Command (write) | `030ff8b1-1e45-4ae6-bf36-3bca4c38cdba` (`trigger_reading_characteristic_2`) |
 | Air Station config (read) | `b47b0cdf-0ced-49a9-86a5-d78a03ea7674` (`air_station_configuration`) |
+| SD log export (read, wifiless Station only; command `0x08`) | `51d2f8a4-91c6-53b2-a6e5-71829304a505` (`sd_log_export_characteristic`) |
 
 Full GATT documentation: [`docs/ble-characteristics.md`](ble-characteristics.md).
 
@@ -27,7 +28,7 @@ After the **first command byte**, the payload is a sequence of records:
 
 | Model | First byte | Notes |
 |-------|------------|--------|
-| **Air Station** | `0x06` (`SET_AIR_STATION_CONFIGURATION`) | Wi‑Fi / geo (`0…8`), MQTT (`9…17`), **`TZ` (`18`)**, **`LOG_LEVEL` (`19`)**, **`api_key` (`20`)**, **`startup.toml` one-shots (`21…25`)** — not MQTT; **`0x07` not** used for these. |
+| **Air Station** | `0x06` (`SET_AIR_STATION_CONFIGURATION`) | Wi‑Fi / geo (`0…8`), MQTT (`9…17`), **`TZ` (`18`)**, **`LOG_LEVEL` (`19`)**, **`api_key` (`20`)**, **`startup.toml` one-shots (`21…25`)** — not MQTT; **`0x07` not** used for these. Also **`0x08`** (**`SD_LOG_EXPORT`**) to stream **wifiless** SD JSONL (see BLE doc UUID `51d2f8a4-…`). |
 | **Air Cube** | `0x07` (`SET_CUBE_MQTT_CONFIGURATION`) | **MQTT flags only** (`9…17`); same record layout as Station. |
 
 ## MQTT flags (`AirstationConfigFlags`)

--- a/firmware/enums.py
+++ b/firmware/enums.py
@@ -314,6 +314,7 @@ class BleCommands:
     TURN_ON_STATUS_LIGHT = 0x05
     SET_AIR_STATION_CONFIGURATION = 0x06
     SET_CUBE_MQTT_CONFIGURATION = 0x07
+    SD_LOG_EXPORT = 0x08
 
 class AirstationConfigFlags:
     AUTO_UPDATE_MODE = 0  # Bit 0

--- a/firmware/ld_service.py
+++ b/firmware/ld_service.py
@@ -59,6 +59,14 @@ class LdService(Service):
         max_length=512,
     )
 
+    # Wifiless Air Station SD JSONL log export chunks (READ after command 0x08)
+    sd_log_export_characteristic = Characteristic(
+        uuid=VendorUUID("51d2f8a4-91c6-53b2-a6e5-71829304a505"),
+        properties=Characteristic.READ,
+        initial_value=bytes([0, 0, 0, 0]),
+        max_length=512,
+    )
+
     '''
     # For requesting that the device take a new sensor reading
     trigger_reading_characteristic_2 = StreamIn(

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -115,6 +115,14 @@ def main():
     # Initialize BLE, define custom service
     ble = BLERadio()
     service = LdService()
+    export_read_value_fn = None
+    try:
+        from sd_ble_export import export_read_value
+
+        export_read_value_fn = export_read_value
+        service.sd_log_export_characteristic = export_read_value()
+    except Exception as e:
+        logger.warning(f"SD BLE export characteristic init skipped ({type(e).__name__}: {e})")
 
     # init ble name
     ble.name = "Luftdaten.at-" + Config.settings['mac']
@@ -321,6 +329,9 @@ def main():
             logger.debug("Disconnected from BLE device")
         
         device.connection_update(ble_connected)
+
+        if ble_connected and Config.is_air_station_wifiless() and export_read_value_fn is not None:
+            service.sd_log_export_characteristic = export_read_value_fn()
 
         if button.value and not button_state:
             button_state = True

--- a/firmware/models/air_station.py
+++ b/firmware/models/air_station.py
@@ -104,6 +104,14 @@ class AirStation(LdProductModel):
         cmd, *data = command
 
         data = bytearray(data)
+        if cmd == BleCommands.SD_LOG_EXPORT:
+            from sd_ble_export import export_read_value, handle_export_command
+
+            act = data[0] if len(data) >= 1 else 255
+            handle_export_command(act, Config.is_air_station_wifiless())
+            self.ble_service.sd_log_export_characteristic = export_read_value()
+            return
+
         if cmd == BleCommands.SET_AIR_STATION_CONFIGURATION:
             wifi_config_changed = self.decode_configuration(data) 
 

--- a/firmware/sd_ble_export.py
+++ b/firmware/sd_ble_export.py
@@ -1,0 +1,206 @@
+"""BLE chunk export for Air Station wifiless JSONL log (see docs/ble-characteristics.md)."""
+
+import os
+import struct
+
+from config import Config
+from logger import logger
+
+# Frame: status u8 + flags u8 + payload_len u16 BE + payload (max 508 bytes → total 512)
+MAX_PAYLOAD = 508
+
+STATUS_IDLE = 0
+STATUS_PARTIAL = 1
+
+STATUS_EOL = 2
+STATUS_EOF = 3
+STATUS_ERR = 4
+
+SUB_NOT_WIFILESS = 1
+SUB_MOUNT_FAIL = 2
+SUB_OPEN_FAIL = 3
+SUB_READ_FAIL = 4
+SUB_NO_SESSION = 5
+
+FLAG_IDLE_SD_LOG_NONEMPTY = 0x01
+
+
+def _stat_size(path):
+    """Return file size or -1 on failure."""
+    try:
+        st = os.stat(path)
+        sz = getattr(st, "st_size", None)
+        if isinstance(sz, int):
+            return sz
+        if isinstance(st, tuple) and len(st) > 6:
+            return int(st[6])
+        return -1
+    except OSError:
+        return -1
+
+
+def _sd_log_file_nonempty():
+    """True if mounted SD has the JSONL path with size > 0."""
+    if not Config.is_air_station_wifiless():
+        return False
+    from sd_logger import ensure_sd_mounted
+
+    if not ensure_sd_mounted():
+        return False
+    path = Config.settings.get("SD_LOG_PATH") or "/sd/measurements.jsonl"
+    return _stat_size(path) > 0
+
+
+def _idle_flags_byte():
+    return FLAG_IDLE_SD_LOG_NONEMPTY if _sd_log_file_nonempty() else 0
+
+
+_STATE_OPEN = "open"
+_STATE_AFTER_EOF = "after_eof"
+
+_last_frame = struct.pack(">BBH", STATUS_IDLE, 0, 0)
+_fh = None
+_pending = ""  # remainder of current JSONL line (UTF-8–safe chunked as str)
+_state = ""  # "", _STATE_OPEN, or _STATE_AFTER_EOF
+
+
+def export_read_value():
+    """Last frame for ``sd_log_export`` characteristic. Refreshes idle ``flags`` (non-empty bit)."""
+    global _last_frame
+    if len(_last_frame) >= 1 and _last_frame[0] == STATUS_IDLE:
+        _last_frame = struct.pack(">BBH", STATUS_IDLE, _idle_flags_byte(), 0)
+    return _last_frame
+
+
+def _set_frame(status, flags, payload_bytes):
+    global _last_frame
+    p = payload_bytes[:MAX_PAYLOAD]
+    ln = len(p)
+    _last_frame = struct.pack(">BBH", status, flags & 0xFF, ln) + p
+
+
+def _set_idle_frame():
+    global _last_frame
+    _last_frame = struct.pack(">BBH", STATUS_IDLE, _idle_flags_byte(), 0)
+
+
+def _close_file():
+    global _fh
+    if _fh is not None:
+        try:
+            _fh.close()
+        except Exception:
+            pass
+        _fh = None
+
+
+def handle_export_command(action, wifiless_ok):
+    """BLE helper: ``action`` 0 = START, 1 = NEXT."""
+    global _pending, _state
+
+    action = int(action) & 0xFF if action is not None else 255
+
+    if not wifiless_ok:
+        _close_file()
+        _pending = ""
+        _state = ""
+        _set_frame(STATUS_ERR, SUB_NOT_WIFILESS, bytes())
+        return
+
+    if action == 0:
+        _export_start()
+
+    elif action == 1:
+        _export_next()
+
+    else:
+        _close_file()
+        _pending = ""
+        _state = ""
+        _set_idle_frame()
+
+
+def _export_start():
+    global _fh, _pending, _state
+
+    _close_file()
+    _pending = ""
+    _state = ""
+
+    from sd_logger import ensure_sd_mounted
+
+    if not ensure_sd_mounted():
+        _set_frame(STATUS_ERR, SUB_MOUNT_FAIL, bytes())
+        return
+
+    path = Config.settings.get("SD_LOG_PATH") or "/sd/measurements.jsonl"
+    try:
+        _fh = open(path, "r")  # noqa SIM115 circuitpython global fh
+        _state = _STATE_OPEN
+        _set_idle_frame()
+    except OSError as e:
+        logger.warning(f"SD BLE export open failed ({type(e).__name__}: {e})")
+        _fh = None
+        _state = ""
+        _set_frame(STATUS_ERR, SUB_OPEN_FAIL, bytes())
+
+
+def _export_next():
+    global _fh, _pending, _state
+
+    if _state == _STATE_AFTER_EOF:
+        _set_idle_frame()
+        return
+
+    if _fh is None:
+        _set_frame(STATUS_ERR, SUB_NO_SESSION, bytes())
+        return
+
+    try:
+        if _pending == "":
+            ln = _fh.readline()
+            if ln == "":
+                _close_file()
+                _pending = ""
+                _state = _STATE_AFTER_EOF
+                _set_frame(STATUS_EOF, 0, bytes())
+                return
+            if not isinstance(ln, str):
+                ln = str(ln, "utf-8")
+            _pending = ln
+
+        frag, remainder = _utf8_safe_prefix_str(_pending, MAX_PAYLOAD)
+        _pending = remainder
+
+        blob = frag.encode("utf-8")
+
+        stat = STATUS_PARTIAL if _pending else STATUS_EOL
+        _set_frame(stat, 0, blob)
+
+    except Exception as e:
+        logger.warning(f"SD BLE export read failed ({type(e).__name__}: {e})")
+        _close_file()
+        _pending = ""
+        _state = ""
+        _set_frame(STATUS_ERR, SUB_READ_FAIL, bytes())
+
+
+def _utf8_safe_prefix_str(s, max_bytes):
+    """Split ``s`` so the UTF-8 encoding of returned prefix fits in ``max_bytes``."""
+    if max_bytes <= 0 or not s:
+        return "", s
+    out = []
+    nbytes = 0
+    i = 0
+    sz = len(s)
+    while i < sz:
+        ch = s[i]
+        b = ch.encode("utf-8")
+        lb = len(b)
+        if nbytes + lb > max_bytes:
+            break
+        out.append(ch)
+        nbytes += lb
+        i += 1
+    prefix = "".join(out)
+    return prefix, s[len(prefix) :]


### PR DESCRIPTION
This commit introduces a new characteristic for exporting JSONL logs via BLE for the Air Station in wifiless mode. The `sd_log_export_characteristic` allows for chunked reading of log data, with commands to start and continue the export process. Documentation has been updated to reflect this new feature, including details on the command structure and expected behavior. Additionally, the firmware has been modified to handle the new export command and manage the log file reading process effectively.