### PR TITLE
Add web deploy tool for CIRCUITPY firmware management

### DIFF
--- a/tools/readme.md
+++ b/tools/readme.md
@@ -56,12 +56,17 @@ The notebook is organized as **three steps**: (1) **flash the board** (`flash_wi
 
 4. Serial port: the notebook **Configuration** section runs **`pick_serial_port_interactive(CFG)`** to list ports and choose one (default **`/dev/tty.usbmodem101`**). Examples: macOS `/dev/tty.usbmodem*`, Linux `/dev/ttyACM*` or `/dev/ttyUSB*`, Windows `COM*`. You can also call **`list_serial_ports()`** from `utils` without changing **`CFG`**.
 
+## Web deploy (browser)
+
+For copying the `firmware/` tree to a mounted `CIRCUITPY` drive without Jupyter, use the static tool in [`web-deploy/`](web-deploy/) (Chrome/Edge on desktop). See [`web-deploy/README.md`](web-deploy/README.md) for browser support and `python3 -m http.server` setup.
+
 ## Layout
 
 | Path | Purpose |
 |------|---------|
 | [`../pyproject.toml`](../pyproject.toml) (repo root) | Declares dependencies for **`uv sync`**; venv lives at **`<repo>/.venv`** |
 | `deploy.ipynb` | Notebook — config, Step 1 flash, Step 2 copy-or-update (uses `boot.toml` on `CIRCUITPY` to choose) |
+| `web-deploy/` | Browser tool — copy `firmware/` to `CIRCUITPY` (Chromium desktop; see README) |
 | `notebook_env.py` | Shared **`activate()`** so setup and serial cells find **`deploy/`** after a kernel restart |
 | `utils.py` | Esptool wrapper, mount wait, tree copy, full flash / update |
 | `settings.toml` | Copied to the device on **full flash** |

--- a/tools/web-deploy/README.md
+++ b/tools/web-deploy/README.md
@@ -1,0 +1,84 @@
+# CIRCUITPY Web Deploy
+
+Browser-based tool to copy the repo **`firmware/`** tree onto a mounted **`CIRCUITPY`** USB volume. It mirrors the copy step of [`deploy.ipynb`](../deploy.ipynb) / [`utils.py`](../utils.py) (Step 2), without serial flashing.
+
+## Quick start
+
+From the repository root (or from this folder):
+
+```bash
+cd tools/web-deploy
+python3 -m http.server 8765
+```
+
+Open **http://localhost:8765/** in a supported browser (see below). Do **not** open `index.html` via `file://` — Chromium often blocks the File System Access API on non-secure origins.
+
+1. **Choose source folder** — select your repo’s `firmware/` directory (must contain `code.py`).
+2. **Choose CIRCUITPY folder** — select the mounted volume root (e.g. `/Volumes/CIRCUITPY` on macOS).
+3. Enable **Preserve settings** for updates (default on).
+4. Click **Copy firmware to device**.
+
+After a successful copy, **eject** the volume before unplugging USB.
+
+## What it does
+
+| Behavior | Python equivalent |
+|----------|-------------------|
+| Recursive copy of `firmware/*` with ignore rules | `copy_firmware_tree` |
+| Skip `.git`, `__pycache__`, `.DS_Store`, `readme.md`, `*.pyc`, etc. | `DEFAULT_IGNORE_NAMES` in `utils.py` |
+| Backup + restore `settings.toml` / `startup.toml` | Simplified `copy_firmware_update` (byte-exact restore, no TOML key merge in v1) |
+| Detect `boot.toml` / `code.py` on device | Notebook Step 2 messaging |
+| Optional install `tools/settings.toml` | `deploy_full_flash_settings` (fetch from `../settings.toml` when served from repo) |
+
+**Not included in v1:** esptool flash, `settings_backups/` slot folders, or deep TOML merge of new template keys. Use the Jupyter notebook for those.
+
+## Browser support evaluation
+
+The tool needs **read/write access to a user-selected folder on disk**. That requires the [File System Access API](https://developer.chrome.com/docs/capabilities/web-apis/file-system-access) picker methods (`showDirectoryPicker` with `createWritable`), not only the origin-private file system (OPFS).
+
+### Recommended (full deploy)
+
+| Browser | Desktop | Write to CIRCUITPY | Notes |
+|---------|---------|-------------------|--------|
+| **Google Chrome** | 86+ (105+ fully) | Yes | Primary target |
+| **Microsoft Edge** | 86+ (105+ fully) | Yes | Same Chromium APIs |
+| **Opera** | 72+ | Yes | Chromium-based |
+| **Brave** | Varies | Often behind flag | Enable native file system / File System Access in `brave://flags` if picker is missing |
+
+### Limited / fallback only
+
+| Browser | Folder write | Fallback in this tool |
+|---------|--------------|------------------------|
+| **Firefox** | No `showDirectoryPicker` for local disk (Mozilla standards position) | Source via **folder upload**; **Download firmware ZIP** for manual unzip onto `CIRCUITPY`. Firefox 151+ has [Web Serial](https://hacks.mozilla.org/2026/05/web-serial-support-in-firefox/) but that does **not** replace mass-storage copy. |
+| **Safari** (macOS / iOS) | No local-disk pickers | Same ZIP / manual copy; use Chrome or Edge on macOS for one-click deploy |
+| **Chrome / Edge Android** | No desktop folder pickers | Use desktop OS or `deploy.ipynb` |
+
+### Runtime detection
+
+The page runs `detectCompatibility()` on load and shows a green / yellow / red panel:
+
+- **Green** — Chromium desktop with `showDirectoryPicker`; deploy button enabled.
+- **Yellow** — folder upload + ZIP only (Firefox, Safari).
+- **Red** — no usable APIs; use `deploy.ipynb`.
+
+### Why not Web Serial?
+
+Web Serial talks to the USB **serial** interface (REPL, esptool). **`CIRCUITPY`** is a separate **USB mass-storage** volume. Copying hundreds of files is done via the filesystem, not the serial port. Adafruit’s browser esptool targets flashing `.bin`, not syncing the whole `firmware/` tree.
+
+## Manual fallback (any browser with folder upload)
+
+1. Use **Choose source (folder upload)** and select `firmware/`.
+2. Click **Download firmware ZIP**.
+3. Unzip the archive onto the root of the `CIRCUITPY` drive (merge/replace files).
+4. Preserve or edit `settings.toml` / `startup.toml` manually as needed.
+
+## Security notes
+
+- The site only accesses folders you explicitly pick; permissions are per-origin and per-folder.
+- Serve locally or from a trusted host; do not host this on a public URL without understanding that users grant folder access to that origin.
+- Close Thonny, serial monitors, and other apps using the device before copying.
+
+## Related
+
+- Full flash + copy + settings backup merge: [`../readme.md`](../readme.md), [`../deploy.ipynb`](../deploy.ipynb)
+- End-user release ZIP: [GitHub Releases](https://github.com/luftdaten-at/firmware/releases)

--- a/tools/web-deploy/app.js
+++ b/tools/web-deploy/app.js
@@ -1,0 +1,624 @@
+/**
+ * CIRCUITPY firmware deploy — browser tool using File System Access API.
+ * Copy semantics aligned with tools/utils.py (copy_firmware_tree / update settings).
+ */
+
+const IGNORE_NAMES = new Set([
+  ".git",
+  ".DS_Store",
+  "__pycache__",
+  ".gitignore",
+  ".idea",
+  ".vscode",
+]);
+
+const IGNORE_SUFFIXES = [".pyc", ".pyo"];
+const SETTINGS_FILES = ["settings.toml", "startup.toml"];
+const MARKER_CODE = "code.py";
+const MARKER_BOOT = "boot.toml";
+
+/** @type {FileSystemDirectoryHandle | null} */
+let sourceHandle = null;
+/** @type {FileSystemDirectoryHandle | null} */
+let destHandle = null;
+/** @type {{ path: string, file: File }[] | null} */
+let sourceFileList = null;
+
+const compat = detectCompatibility();
+
+const els = {
+  compatPanel: document.getElementById("compat-panel"),
+  btnPickSource: document.getElementById("btn-pick-source"),
+  btnPickDest: document.getElementById("btn-pick-dest"),
+  btnDeploy: document.getElementById("btn-deploy"),
+  btnDownloadZip: document.getElementById("btn-download-zip"),
+  sourceSummary: document.getElementById("source-summary"),
+  destSummary: document.getElementById("dest-summary"),
+  destValidation: document.getElementById("dest-validation"),
+  sourceFallbackLabel: document.getElementById("source-fallback-label"),
+  inputSourceDir: document.getElementById("input-source-dir"),
+  optPreserveSettings: document.getElementById("opt-preserve-settings"),
+  optInstallToolsSettings: document.getElementById("opt-install-tools-settings"),
+  progressPanel: document.getElementById("progress-panel"),
+  progressBar: document.getElementById("progress-bar"),
+  progressText: document.getElementById("progress-text"),
+  log: document.getElementById("log"),
+  reportPanel: document.getElementById("report-panel"),
+  reportStats: document.getElementById("report-stats"),
+  reportNote: document.getElementById("report-note"),
+};
+
+init();
+
+function init() {
+  renderCompatPanel();
+  els.btnPickSource.disabled = !compat.canPickDirectories;
+  els.btnPickDest.disabled = !compat.canWriteToDevice;
+  els.btnDeploy.disabled = !compat.canWriteToDevice;
+  els.btnDownloadZip.disabled = false;
+
+  if (!compat.canPickDirectories) {
+    els.sourceFallbackLabel.classList.remove("hidden");
+  }
+
+  els.btnPickSource.addEventListener("click", pickSourceDirectory);
+  els.btnPickDest.addEventListener("click", pickDestDirectory);
+  els.btnDeploy.addEventListener("click", runDeploy);
+  els.btnDownloadZip.addEventListener("click", downloadFirmwareZip);
+  els.inputSourceDir.addEventListener("change", onSourceDirUpload);
+
+  updateDeployButtonState();
+}
+
+/**
+ * @returns {{
+ *   canPickDirectories: boolean,
+ *   canWriteToDevice: boolean,
+ *   browserName: string,
+ *   level: 'ok' | 'warn' | 'err',
+ *   messages: string[],
+ * }}
+ */
+function detectCompatibility() {
+  const ua = navigator.userAgent;
+  let browserName = "Unknown browser";
+  if (/Edg\//.test(ua)) browserName = "Microsoft Edge";
+  else if (/Chrome\//.test(ua) && !/Edg\//.test(ua)) browserName = "Google Chrome";
+  else if (/OPR\//.test(ua) || /Opera/.test(ua)) browserName = "Opera";
+  else if (/Firefox\//.test(ua)) browserName = "Firefox";
+  else if (/Safari\//.test(ua) && !/Chrome/.test(ua)) browserName = "Safari";
+
+  const canPick =
+    typeof window.showDirectoryPicker === "function" &&
+    typeof FileSystemHandle !== "undefined";
+  const canWrite = canPick;
+  const messages = [];
+
+  if (canWrite) {
+    messages.push(
+      `${browserName} supports folder pickers and writing to CIRCUITPY.`,
+    );
+    messages.push(
+      "Serve this page over http://localhost (see README) — opening index.html as file:// may block APIs.",
+    );
+    if (/Brave/.test(ua)) {
+      messages.push(
+        "Brave may require enabling the File System Access API in brave://flags.",
+      );
+    }
+    return {
+      canPickDirectories: true,
+      canWriteToDevice: true,
+      browserName,
+      level: "ok",
+      messages,
+    };
+  }
+
+  const hasDirUpload =
+    typeof HTMLInputElement !== "undefined" &&
+    "webkitdirectory" in document.createElement("input");
+
+  if (hasDirUpload) {
+    messages.push(
+      `${browserName} cannot write directly to CIRCUITPY (no showDirectoryPicker).`,
+    );
+    messages.push(
+      "You can still pick a source folder and download a ZIP to copy manually.",
+    );
+    messages.push(
+      "For full deploy (including settings preserve), use Chrome or Edge on desktop.",
+    );
+    return {
+      canPickDirectories: false,
+      canWriteToDevice: false,
+      browserName,
+      level: "warn",
+      messages,
+    };
+  }
+
+  messages.push(
+    `${browserName} does not support the APIs needed for this tool.`,
+  );
+  messages.push("Use Chrome or Edge on desktop, or tools/deploy.ipynb.");
+  return {
+    canPickDirectories: false,
+    canWriteToDevice: false,
+    browserName,
+    level: "err",
+    messages,
+  };
+}
+
+function renderCompatPanel() {
+  const { level, browserName, messages } = compat;
+  els.compatPanel.className = `panel compat ${level}`;
+  els.compatPanel.innerHTML = `
+    <strong>Browser: ${escapeHtml(browserName)}</strong>
+    <ul>${messages.map((m) => `<li>${escapeHtml(m)}</li>`).join("")}</ul>
+  `;
+}
+
+async function pickSourceDirectory() {
+  try {
+    const handle = await window.showDirectoryPicker({ mode: "read" });
+    const ok = await validateSourceHandle(handle);
+    if (!ok) return;
+    sourceHandle = handle;
+    sourceFileList = null;
+    els.sourceSummary.textContent = `Source: ${handle.name}/ (${await countFilesInTree(handle)} files)`;
+    updateDeployButtonState();
+    logLine(`Selected source: ${handle.name}`);
+  } catch (e) {
+    if (e.name !== "AbortError") logLine(`Source pick failed: ${e.message}`, true);
+  }
+}
+
+async function onSourceDirUpload(ev) {
+  const files = /** @type {FileList} */ (ev.target.files);
+  if (!files?.length) return;
+  const list = [];
+  let hasCodePy = false;
+  for (const file of files) {
+    const path = file.webkitRelativePath || file.name;
+    const rel = path.includes("/") ? path.split("/").slice(1).join("/") : path;
+    if (rel === MARKER_CODE || rel.endsWith(`/${MARKER_CODE}`)) hasCodePy = true;
+    if (shouldSkipName(path.split("/").pop() || path)) continue;
+    const norm = rel.replace(/^\/+/, "");
+    if (!norm || shouldSkipPath(norm)) continue;
+    list.push({ path: norm, file });
+  }
+  if (!hasCodePy) {
+    alert(`Selected folder must contain ${MARKER_CODE} at the top level.`);
+    return;
+  }
+  sourceHandle = null;
+  sourceFileList = list;
+  els.sourceSummary.textContent = `Source (upload): ${list.length} files`;
+  updateDeployButtonState();
+  logLine(`Source from folder upload: ${list.length} files`);
+}
+
+async function pickDestDirectory() {
+  try {
+    const handle = await window.showDirectoryPicker({ mode: "readwrite" });
+    destHandle = handle;
+    els.destSummary.textContent = `Destination: ${handle.name}/`;
+    await validateDestination(handle);
+    updateDeployButtonState();
+    logLine(`Selected destination: ${handle.name}`);
+  } catch (e) {
+    if (e.name !== "AbortError") logLine(`Destination pick failed: ${e.message}`, true);
+  }
+}
+
+async function validateSourceHandle(handle) {
+  try {
+    await handle.getFileHandle(MARKER_CODE);
+    return true;
+  } catch {
+    alert(
+      `“${handle.name}” does not contain ${MARKER_CODE}. Select the repo firmware/ folder.`,
+    );
+    return false;
+  }
+}
+
+async function validateDestination(handle) {
+  const el = els.destValidation;
+  el.hidden = false;
+  let hasCode = false;
+  let hasBoot = false;
+  try {
+    await handle.getFileHandle(MARKER_CODE);
+    hasCode = true;
+  } catch {
+    /* missing */
+  }
+  try {
+    await handle.getFileHandle(MARKER_BOOT);
+    hasBoot = true;
+  } catch {
+    /* missing */
+  }
+
+  if (hasBoot) {
+    el.className = "validation ok";
+    el.textContent =
+      "Update path: boot.toml found — existing board (settings can be preserved).";
+  } else if (hasCode) {
+    el.className = "validation warn";
+    el.textContent =
+      "code.py present but no boot.toml — treated as new-board style copy.";
+  } else {
+    el.className = "validation warn";
+    el.textContent =
+      "No code.py on device yet — ensure this is the CIRCUITPY root.";
+  }
+}
+
+function updateDeployButtonState() {
+  const hasSource = sourceHandle != null || (sourceFileList?.length ?? 0) > 0;
+  els.btnDeploy.disabled = !compat.canWriteToDevice || !hasSource || !destHandle;
+  els.btnDownloadZip.disabled = !hasSource;
+}
+
+function shouldSkipName(name) {
+  if (IGNORE_NAMES.has(name)) return true;
+  if (name.toLowerCase() === "readme.md") return true;
+  return IGNORE_SUFFIXES.some((s) => name.endsWith(s));
+}
+
+function shouldSkipPath(relPath) {
+  const parts = relPath.split("/");
+  return parts.some((p) => shouldSkipName(p));
+}
+
+/**
+ * Collect copy jobs: top-level entries of src, mirroring utils._collect_firmware_copy_jobs.
+ * @param {FileSystemDirectoryHandle} srcDir
+ * @returns {Promise<{ relPath: string, getBlob: () => Promise<Blob> }[]>}
+ */
+async function collectJobsFromHandle(srcDir) {
+  const jobs = [];
+
+  async function walkDir(dirHandle, prefix) {
+    for await (const [name, handle] of dirHandle.entries()) {
+      if (shouldSkipName(name)) continue;
+      const rel = prefix ? `${prefix}/${name}` : name;
+      if (handle.kind === "directory") {
+        await walkDir(handle, rel);
+      } else {
+        jobs.push({
+          relPath: rel,
+          getBlob: async () => {
+            const fh = /** @type {FileSystemFileHandle} */ (handle);
+            const f = await fh.getFile();
+            return f;
+          },
+        });
+      }
+    }
+  }
+
+  const entries = [];
+  for await (const entry of srcDir.entries()) {
+    entries.push(entry);
+  }
+  entries.sort((a, b) => a[0].localeCompare(b[0], undefined, { sensitivity: "base" }));
+
+  for (const [name, handle] of entries) {
+    if (shouldSkipName(name)) continue;
+    if (handle.kind === "directory") {
+      await walkDir(handle, name);
+    } else {
+      const fh = /** @type {FileSystemFileHandle} */ (handle);
+      jobs.push({
+        relPath: name,
+        getBlob: () => fh.getFile(),
+      });
+    }
+  }
+  return jobs;
+}
+
+function collectJobsFromFileList(list) {
+  return list
+    .filter(({ path }) => !shouldSkipPath(path))
+    .map(({ path, file }) => ({
+      relPath: path,
+      getBlob: async () => file,
+    }));
+}
+
+async function getAllJobs() {
+  if (sourceHandle) return collectJobsFromHandle(sourceHandle);
+  if (sourceFileList) return collectJobsFromFileList(sourceFileList);
+  throw new Error("No firmware source selected.");
+}
+
+/**
+ * @param {FileSystemDirectoryHandle} root
+ * @param {string} relPath
+ */
+async function writeFileToDest(root, relPath, blob) {
+  const parts = relPath.split("/");
+  const fileName = parts.pop();
+  let dir = root;
+  for (const part of parts) {
+    dir = await dir.getDirectoryHandle(part, { create: true });
+  }
+  const fileHandle = await dir.getFileHandle(fileName, { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(blob);
+  await writable.close();
+}
+
+/**
+ * @param {FileSystemDirectoryHandle} root
+ * @param {string} name
+ */
+async function readFileBytes(root, name) {
+  try {
+    const fh = await root.getFileHandle(name);
+    const file = await fh.getFile();
+    return new Uint8Array(await file.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {FileSystemDirectoryHandle} root
+ * @param {string} name
+ * @param {Uint8Array} data
+ */
+async function writeFileBytes(root, name, data) {
+  const fh = await root.getFileHandle(name, { create: true });
+  const writable = await fh.createWritable();
+  await writable.write(data);
+  await writable.close();
+}
+
+async function fileExists(root, name) {
+  try {
+    await root.getFileHandle(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function countFilesInTree(dirHandle) {
+  const jobs = await collectJobsFromHandle(dirHandle);
+  return jobs.length;
+}
+
+async function runDeploy() {
+  if (!destHandle) return;
+  els.progressPanel.classList.remove("hidden");
+  els.reportPanel.classList.add("hidden");
+  els.log.textContent = "";
+  els.progressBar.value = 0;
+
+  const preserve = els.optPreserveSettings.checked;
+  const stats = { copied: 0, skipped: 0, failed: 0, restored: 0 };
+
+  try {
+    const jobs = await getAllJobs();
+    const total = jobs.length;
+    els.progressBar.max = total;
+
+    const backups = {};
+    if (preserve) {
+      for (const name of SETTINGS_FILES) {
+        const data = await readFileBytes(destHandle, name);
+        if (data) {
+          backups[name] = data;
+          logLine(`Backed up ${name} (${data.byteLength} bytes)`);
+        }
+      }
+    }
+
+    const skipSettingsDuringCopy =
+      preserve && Object.keys(backups).length > 0;
+
+    for (let i = 0; i < jobs.length; i++) {
+      const { relPath, getBlob } = jobs[i];
+      els.progressText.textContent = `${i + 1} / ${total}: ${relPath}`;
+      els.progressBar.value = i + 1;
+
+      const base = relPath.split("/").pop();
+      if (
+        skipSettingsDuringCopy &&
+        SETTINGS_FILES.includes(base) &&
+        backups[base]
+      ) {
+        stats.skipped++;
+        continue;
+      }
+
+      try {
+        const blob = await getBlob();
+        await writeFileToDest(destHandle, relPath, blob);
+        stats.copied++;
+        if ((i + 1) % 25 === 0 || i === total - 1) {
+          logLine(`Copied ${i + 1}/${total} …`);
+        }
+      } catch (e) {
+        stats.failed++;
+        logLine(`FAILED ${relPath}: ${e.message}`, true);
+      }
+    }
+
+    if (preserve && Object.keys(backups).length) {
+      for (const [name, data] of Object.entries(backups)) {
+        await writeFileBytes(destHandle, name, data);
+        stats.restored++;
+        logLine(`Restored ${name}`);
+      }
+    }
+
+    if (els.optInstallToolsSettings.checked) {
+      await tryInstallBundledSettings();
+    }
+
+    showReport(stats, total);
+    logLine("Deploy finished. Eject CIRCUITPY safely before unplugging.");
+  } catch (e) {
+    logLine(`Deploy aborted: ${e.message}`, true);
+    alert(e.message);
+  }
+}
+
+async function tryInstallBundledSettings() {
+  try {
+    const res = await fetch("../settings.toml");
+    if (!res.ok) {
+      logLine("tools/settings.toml not available from this server path.", true);
+      return;
+    }
+    const text = await res.text();
+    const blob = new Blob([text], { type: "application/toml" });
+    await writeFileToDest(destHandle, "settings.toml", blob);
+    logLine("Installed default tools/settings.toml onto device.");
+  } catch (e) {
+    logLine(`Could not install tools/settings.toml: ${e.message}`, true);
+  }
+}
+
+function showReport(stats, total) {
+  els.reportPanel.classList.remove("hidden");
+  els.reportStats.innerHTML = `
+    <dt>Files planned</dt><dd>${total}</dd>
+    <dt>Copied</dt><dd>${stats.copied}</dd>
+    <dt>Skipped (preserved settings)</dt><dd>${stats.skipped}</dd>
+    <dt>Failed</dt><dd>${stats.failed}</dd>
+    <dt>Settings restored</dt><dd>${stats.restored}</dd>
+  `;
+  els.reportNote.textContent =
+    stats.failed === 0
+      ? "Copy completed. Safely eject the CIRCUITPY volume before disconnecting USB."
+      : "Some files failed — retry after closing serial monitors and ejecting other apps using the port.";
+}
+
+async function downloadFirmwareZip() {
+  els.progressPanel.classList.remove("hidden");
+  els.log.textContent = "";
+  logLine("Building ZIP…");
+  try {
+    const jobs = await getAllJobs();
+    const zipBlob = await buildStoredZip(jobs);
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(zipBlob);
+    a.download = "firmware-circuitpy.zip";
+    a.click();
+    URL.revokeObjectURL(a.href);
+    logLine(`ZIP ready (${jobs.length} files). Unzip onto CIRCUITPY.`);
+  } catch (e) {
+    logLine(`ZIP failed: ${e.message}`, true);
+    alert(e.message);
+  }
+}
+
+/**
+ * Minimal ZIP (store only, no compression).
+ * @param {{ relPath: string, getBlob: () => Promise<Blob> }[]} jobs
+ */
+async function buildStoredZip(jobs) {
+  const chunks = [];
+  const central = [];
+  let offset = 0;
+
+  for (const { relPath, getBlob } of jobs) {
+    const blob = await getBlob();
+    const buf = new Uint8Array(await blob.arrayBuffer());
+    const nameBytes = new TextEncoder().encode(relPath.replace(/\\/g, "/"));
+    const crc = crc32(buf);
+    const localHeader = new Uint8Array(30 + nameBytes.length);
+    const view = new DataView(localHeader.buffer);
+    view.setUint32(0, 0x04034b50, true);
+    view.setUint16(6, 0, true);
+    view.setUint16(8, 0, true);
+    view.setUint16(10, 0, true);
+    view.setUint16(12, 0, true);
+    view.setUint32(14, crc, true);
+    view.setUint32(18, buf.length, true);
+    view.setUint32(22, buf.length, true);
+    view.setUint16(26, nameBytes.length, true);
+    view.setUint16(28, 0, true);
+    localHeader.set(nameBytes, 30);
+    chunks.push(localHeader, buf);
+
+    const cd = new Uint8Array(46 + nameBytes.length);
+    const cdv = new DataView(cd.buffer);
+    cdv.setUint32(0, 0x02014b50, true);
+    cdv.setUint16(8, 0, true);
+    cdv.setUint16(10, 0, true);
+    cdv.setUint16(12, 0, true);
+    cdv.setUint16(14, 0, true);
+    cdv.setUint32(16, crc, true);
+    cdv.setUint32(20, buf.length, true);
+    cdv.setUint32(24, buf.length, true);
+    cdv.setUint16(28, nameBytes.length, true);
+    cdv.setUint16(30, 0, true);
+    cdv.setUint16(32, 0, true);
+    cdv.setUint16(34, 0, true);
+    cdv.setUint32(38, 0, true);
+    cdv.setUint32(42, offset, true);
+    cd.set(nameBytes, 46);
+    central.push(cd);
+    offset += localHeader.length + buf.length;
+  }
+
+  const centralSize = central.reduce((s, c) => s + c.length, 0);
+  const end = new Uint8Array(22);
+  const endv = new DataView(end.buffer);
+  endv.setUint32(0, 0x06054b50, true);
+  endv.setUint16(8, jobs.length, true);
+  endv.setUint16(10, jobs.length, true);
+  endv.setUint32(12, centralSize, true);
+  endv.setUint32(16, offset, true);
+  endv.setUint16(20, 0, true);
+
+  return new Blob([...chunks, ...central, end], { type: "application/zip" });
+}
+
+/** CRC-32 (IEEE) for ZIP */
+function crc32(data) {
+  let c = 0xffffffff;
+  const table = crc32.table || (crc32.table = makeCrcTable());
+  for (let i = 0; i < data.length; i++) {
+    c = table[(c ^ data[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function makeCrcTable() {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    t[n] = c;
+  }
+  return t;
+}
+
+function logLine(msg, isErr = false) {
+  const line = `[${new Date().toLocaleTimeString()}] ${msg}\n`;
+  els.log.textContent += line;
+  if (isErr) console.error(msg);
+  else console.log(msg);
+  els.log.scrollTop = els.log.scrollHeight;
+}
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/tools/web-deploy/index.html
+++ b/tools/web-deploy/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CIRCUITPY Firmware Deploy</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header>
+        <h1>CIRCUITPY Firmware Deploy</h1>
+        <p class="subtitle">
+          Copy the newest firmware tree from your workspace onto a mounted
+          <code>CIRCUITPY</code> drive.
+        </p>
+      </header>
+
+      <section id="compat-panel" class="panel compat" aria-live="polite"></section>
+
+      <section class="panel">
+        <h2>1. Firmware source</h2>
+        <p class="hint">
+          Select the repo <code>firmware/</code> folder (must contain
+          <code>code.py</code>).
+        </p>
+        <div class="row">
+          <button type="button" id="btn-pick-source" class="primary" disabled>
+            Choose source folder
+          </button>
+          <label class="fallback-label hidden" id="source-fallback-label">
+            <span class="btn secondary">Choose source (folder upload)</span>
+            <input
+              type="file"
+              id="input-source-dir"
+              webkitdirectory
+              directory
+              multiple
+              hidden
+            />
+          </label>
+        </div>
+        <p id="source-summary" class="summary muted">No source selected.</p>
+      </section>
+
+      <section class="panel">
+        <h2>2. Destination (CIRCUITPY)</h2>
+        <p class="hint">
+          Pick the mounted <code>CIRCUITPY</code> volume root (e.g.
+          <code>/Volumes/CIRCUITPY</code> on macOS).
+        </p>
+        <button type="button" id="btn-pick-dest" class="primary" disabled>
+          Choose CIRCUITPY folder
+        </button>
+        <p id="dest-summary" class="summary muted">No destination selected.</p>
+        <p id="dest-validation" class="validation" hidden></p>
+      </section>
+
+      <section class="panel">
+        <h2>3. Options</h2>
+        <label class="checkbox">
+          <input type="checkbox" id="opt-preserve-settings" checked />
+          Preserve <code>settings.toml</code> and <code>startup.toml</code> on
+          the device (recommended for updates)
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" id="opt-install-tools-settings" />
+          After copy, install default <code>tools/settings.toml</code> from this
+          page (new-board helper; only if you loaded this tool from the repo)
+        </label>
+        <p class="hint small">
+          Matches the notebook: if <code>boot.toml</code> exists on the device,
+          this run is treated as an <strong>update</strong>; otherwise a
+          <strong>new board</strong> copy.
+        </p>
+      </section>
+
+      <section class="panel actions">
+        <button type="button" id="btn-deploy" class="primary large" disabled>
+          Copy firmware to device
+        </button>
+        <button type="button" id="btn-download-zip" class="secondary" disabled>
+          Download firmware ZIP (manual copy fallback)
+        </button>
+      </section>
+
+      <section class="panel progress-panel hidden" id="progress-panel">
+        <h2>Progress</h2>
+        <progress id="progress-bar" max="100" value="0"></progress>
+        <p id="progress-text" class="summary muted"></p>
+        <pre id="log" class="log" aria-live="polite"></pre>
+      </section>
+
+      <section class="panel report hidden" id="report-panel">
+        <h2>Result</h2>
+        <dl id="report-stats" class="stats"></dl>
+        <p id="report-note" class="hint"></p>
+      </section>
+
+      <footer>
+        <p>
+          See
+          <a href="README.md">README.md</a>
+          for browser support. Python workflow:
+          <code>tools/deploy.ipynb</code>.
+        </p>
+      </footer>
+    </main>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/tools/web-deploy/styles.css
+++ b/tools/web-deploy/styles.css
@@ -1,0 +1,241 @@
+:root {
+  --bg: #0f1419;
+  --surface: #1a2332;
+  --border: #2d3a4f;
+  --text: #e7ecf3;
+  --muted: #8b9cb3;
+  --accent: #3d8bfd;
+  --accent-hover: #5a9dff;
+  --ok: #3dd68c;
+  --warn: #f5c542;
+  --err: #f87171;
+  --radius: 8px;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.app {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1.5rem 1.25rem 3rem;
+}
+
+header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.5rem;
+  font-weight: 650;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.panel {
+  margin-top: 1.25rem;
+  padding: 1rem 1.1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.hint.small {
+  margin-top: 0.75rem;
+  margin-bottom: 0;
+}
+
+.hint code,
+.summary code {
+  font-size: 0.85em;
+  background: var(--bg);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+button,
+.btn {
+  cursor: pointer;
+  font: inherit;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.9rem;
+  background: var(--surface);
+  color: var(--text);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+button.primary,
+.btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+button.primary:not(:disabled):hover,
+.btn.primary:not(:disabled):hover {
+  background: var(--accent-hover);
+}
+
+button.secondary,
+.btn.secondary {
+  background: transparent;
+}
+
+button.large {
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.checkbox {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.checkbox input {
+  margin-top: 0.2rem;
+}
+
+.summary {
+  margin: 0.6rem 0 0;
+  font-size: 0.875rem;
+}
+
+.summary.muted {
+  color: var(--muted);
+}
+
+.compat {
+  font-size: 0.875rem;
+}
+
+.compat.ok {
+  border-color: color-mix(in srgb, var(--ok) 40%, var(--border));
+}
+
+.compat.warn {
+  border-color: color-mix(in srgb, var(--warn) 40%, var(--border));
+}
+
+.compat.err {
+  border-color: color-mix(in srgb, var(--err) 40%, var(--border));
+}
+
+.compat ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.validation {
+  margin: 0.5rem 0 0;
+  font-size: 0.875rem;
+}
+
+.validation.warn {
+  color: var(--warn);
+}
+
+.validation.ok {
+  color: var(--ok);
+}
+
+.hidden {
+  display: none !important;
+}
+
+progress {
+  width: 100%;
+  height: 0.5rem;
+  accent-color: var(--accent);
+}
+
+.log {
+  margin: 0.75rem 0 0;
+  max-height: 220px;
+  overflow: auto;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.6rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 1rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.stats dt {
+  color: var(--muted);
+}
+
+.stats dd {
+  margin: 0;
+}
+
+footer {
+  margin-top: 2rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+footer a {
+  color: var(--accent);
+}


### PR DESCRIPTION
This commit introduces a new browser-based tool for copying the firmware tree to a mounted CIRCUITPY drive, utilizing the File System Access API. The tool includes a user interface for selecting source and destination directories, with options to preserve settings during updates. Documentation has been added to guide users on setup and browser compatibility. Additionally, the README and styles for the web tool have been created to enhance user experience and provide necessary instructions.