### PR TITLE
Add BMP581 sensor support and update documentation

### DIFF
--- a/firmware/enums.py
+++ b/firmware/enums.py
@@ -44,6 +44,7 @@ class SensorModel():
     TSL2591 = 25
     SEN63C = 26
     SEN62 = 27
+    BMP581 = 28
 
     _names = {
         SEN5X: "SEN5X",
@@ -73,6 +74,7 @@ class SensorModel():
         TSL2591: "TSL_2591",
         SEN63C: "SEN63C",
         SEN62: "SEN62",
+        BMP581: "BMP581",
     }
 
     _manufacturer = {
@@ -99,6 +101,7 @@ class SensorModel():
         TSL2591: "ams OSRAM",
         SEN63C: "Sensirion",
         SEN62: "Sensirion",
+        BMP581: "Bosch Sensortec",
     }
 
     _pins = {
@@ -109,6 +112,7 @@ class SensorModel():
         BME280: 11,
         BME680: 11,
         BMP280: 3,
+        BMP581: 3,
         DHT22: 7,
         SHT30: 7,
         SHT31: 7,

--- a/firmware/lib/adafruit_register/i2c_bcd_alarm.py
+++ b/firmware/lib/adafruit_register/i2c_bcd_alarm.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2016 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_register.i2c_bcd_alarm`
+====================================================
+
+Binary Coded Decimal alarm register
+
+* Author(s): Scott Shawcroft
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+import time
+
+try:
+    from typing import Optional, Tuple, Type
+
+    from circuitpython_typing.device_drivers import I2CDeviceDriver
+    from typing_extensions import Literal
+
+    FREQUENCY_T = Literal["monthly", "weekly", "daily", "hourly", "minutely", "secondly"]
+except ImportError:
+    pass
+
+
+def _bcd2bin(value: int) -> int:
+    """Convert binary coded decimal to Binary
+
+    :param value: the BCD value to convert to binary (required, no default)
+    """
+    return value - 6 * (value >> 4)
+
+
+def _bin2bcd(value: int) -> int:
+    """Convert a binary value to binary coded decimal.
+
+    :param value: the binary value to convert to BCD. (required, no default)
+    """
+    return value + 6 * (value // 10)
+
+
+ALARM_COMPONENT_DISABLED = 0x80
+FREQUENCY = ["secondly", "minutely", "hourly", "daily", "weekly", "monthly"]
+
+
+class BCDAlarmTimeRegister:
+    """
+    Alarm date and time register using binary coded decimal structure.
+
+    The byte order of the registers must* be: [second], minute, hour, day,
+    weekday. Each byte must also have a high enable bit where 1 is disabled and
+    0 is enabled.
+
+    * If weekday_shared is True, then weekday and day share a register.
+    * If has_seconds is True, then there is a seconds register.
+
+    Values are a tuple of (`time.struct_time`, `str`) where the struct represents
+    a date and time that would alarm. The string is the frequency:
+
+    * "secondly", once a second (only if alarm has_seconds)
+    * "minutely", once a minute when seconds match (if alarm doesn't seconds then when seconds = 0)
+    * "hourly", once an hour when ``tm_min`` and ``tm_sec`` match
+    * "daily", once a day when ``tm_hour``, ``tm_min`` and ``tm_sec`` match
+    * "weekly", once a week when ``tm_wday``, ``tm_hour``, ``tm_min``, ``tm_sec`` match
+    * "monthly", once a month when ``tm_mday``, ``tm_hour``, ``tm_min``, ``tm_sec`` match
+
+    :param int register_address: The register address to start the read
+    :param bool has_seconds: True if the alarm can happen minutely.
+    :param bool weekday_shared: True if weekday and day share the same register
+    :param int weekday_start: 0 or 1 depending on the RTC's representation of the first day of the
+      week (Monday)
+    """
+
+    # Defaults are based on alarm1 of the DS3231.
+    def __init__(
+        self,
+        register_address: int,
+        has_seconds: bool = True,
+        weekday_shared: bool = True,
+        weekday_start: Literal[0, 1] = 1,
+    ) -> None:
+        buffer_size = 5
+        if weekday_shared:
+            buffer_size -= 1
+        if has_seconds:
+            buffer_size += 1
+        self.has_seconds = has_seconds
+        self.buffer = bytearray(buffer_size)
+        self.buffer[0] = register_address
+        self.weekday_shared = weekday_shared
+        self.weekday_start = weekday_start
+
+    def __get__(
+        self,
+        obj: Optional[I2CDeviceDriver],
+        objtype: Optional[Type[I2CDeviceDriver]] = None,
+    ) -> Tuple[time.struct_time, FREQUENCY_T]:
+        # Read the alarm register.
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
+
+        frequency = None
+        i = 1
+        seconds = 0
+        if self.has_seconds:
+            if (self.buffer[1] & 0x80) != 0:
+                frequency = "secondly"
+            else:
+                frequency = "minutely"
+                seconds = _bcd2bin(self.buffer[1] & 0x7F)
+            i = 2
+        else:
+            frequency = "minutely"
+            seconds = _bcd2bin(self.buffer[i] & 0x7F)
+        minute = 0
+        if (self.buffer[i] & 0x80) == 0:
+            frequency = "hourly"
+            minute = _bcd2bin(self.buffer[i] & 0x7F)
+
+        hour = 0
+        if (self.buffer[i + 1] & 0x80) == 0:
+            frequency = "daily"
+            hour = _bcd2bin(self.buffer[i + 1] & 0x7F)
+
+        mday = None
+        wday = None
+        if (self.buffer[i + 2] & 0x80) == 0:
+            # day of the month
+            if not self.weekday_shared or (self.buffer[i + 2] & 0x40) == 0:
+                frequency = "monthly"
+                mday = _bcd2bin(self.buffer[i + 2] & 0x3F)
+            else:  # weekday
+                frequency = "weekly"
+                wday = _bcd2bin(self.buffer[i + 2] & 0x3F) - self.weekday_start
+
+        # weekday
+        if not self.weekday_shared and (self.buffer[i + 3] & 0x80) == 0:
+            frequency = "monthly"
+            mday = _bcd2bin(self.buffer[i + 3] & 0x7F)
+
+        if mday is not None:
+            wday = (mday - 2) % 7
+        elif wday is not None:
+            mday = wday + 2
+        else:
+            # Jan 1, 2017 was a Sunday (6)
+            wday = 6
+            mday = 1
+
+        return (
+            time.struct_time((2017, 1, mday, hour, minute, seconds, wday, mday, -1)),
+            frequency,
+        )
+
+    def __set__(self, obj: I2CDeviceDriver, value: Tuple[time.struct_time, FREQUENCY_T]) -> None:
+        if len(value) != 2:
+            raise ValueError("Value must be sequence of length two")
+        # Turn all components off by default.
+        for i in range(len(self.buffer) - 1):
+            self.buffer[i + 1] = ALARM_COMPONENT_DISABLED
+        frequency_name = value[1]
+        error_message = f"{frequency_name} is not a supported frequency"
+        if frequency_name not in FREQUENCY:
+            raise ValueError(error_message)
+
+        frequency = FREQUENCY.index(frequency_name)
+        if frequency < 1 and not self.has_seconds:
+            raise ValueError(error_message)
+
+        # i is the index of the minute byte
+        i = 2 if self.has_seconds else 1
+
+        if frequency > 0 and self.has_seconds:  # minutely at least
+            self.buffer[1] = _bin2bcd(value[0].tm_sec)
+
+        if frequency > 1:  # hourly at least
+            self.buffer[i] = _bin2bcd(value[0].tm_min)
+
+        if frequency > 2:  # daily at least
+            self.buffer[i + 1] = _bin2bcd(value[0].tm_hour)
+
+        if value[1] == "weekly":
+            if self.weekday_shared:
+                self.buffer[i + 2] = _bin2bcd(value[0].tm_wday + self.weekday_start) | 0x40
+            else:
+                self.buffer[i + 3] = _bin2bcd(value[0].tm_wday + self.weekday_start)
+        elif value[1] == "monthly":
+            self.buffer[i + 2] = _bin2bcd(value[0].tm_mday)
+
+        with obj.i2c_device:
+            obj.i2c_device.write(self.buffer)

--- a/firmware/lib/adafruit_register/i2c_bcd_datetime.py
+++ b/firmware/lib/adafruit_register/i2c_bcd_datetime.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2016 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_register.i2c_bcd_datetime`
+====================================================
+
+Binary Coded Decimal date and time register
+
+* Author(s): Scott Shawcroft
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+import time
+
+try:
+    from typing import Optional, Type
+
+    from circuitpython_typing.device_drivers import I2CDeviceDriver
+    from typing_extensions import Literal
+except ImportError:
+    pass
+
+
+def _bcd2bin(value: int) -> int:
+    """Convert binary coded decimal to Binary
+
+    :param value: the BCD value to convert to binary (required, no default)
+    """
+    return value - 6 * (value >> 4)
+
+
+def _bin2bcd(value: int) -> int:
+    """Convert a binary value to binary coded decimal.
+
+    :param value: the binary value to convert to BCD. (required, no default)
+    """
+    return value + 6 * (value // 10)
+
+
+class BCDDateTimeRegister:
+    """
+    Date and time register using binary coded decimal structure.
+
+    The byte order of the register must* be: second, minute, hour, weekday, day (1-31), month, year
+    (in years after 2000).
+
+    * Setting weekday_first=False will flip the weekday/day order so that day comes first.
+
+    Values are `time.struct_time`
+
+    :param int register_address: The register address to start the read
+    :param bool weekday_first: True if weekday is in a lower register than the day of the month
+        (1-31)
+    :param int weekday_start: 0 or 1 depending on the RTC's representation of the first day of the
+        week
+    """
+
+    def __init__(
+        self,
+        register_address: int,
+        weekday_first: bool = True,
+        weekday_start: Literal[0, 1] = 1,
+    ) -> None:
+        self.buffer = bytearray(8)
+        self.buffer[0] = register_address
+        if weekday_first:
+            self.weekday_offset = 0
+        else:
+            self.weekday_offset = 1
+        self.weekday_start = weekday_start
+        # Masking value list   n/a  sec min hr day wkday mon year
+        self.mask_datetime = b"\xff\x7f\x7f\x3f\x3f\x07\x1f\xff"
+
+    def __get__(
+        self,
+        obj: Optional[I2CDeviceDriver],
+        objtype: Optional[Type[I2CDeviceDriver]] = None,
+    ) -> time.struct_time:
+        # Read and return the date and time.
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
+        return time.struct_time(
+            (
+                _bcd2bin(self.buffer[7] & self.mask_datetime[7]) + 2000,
+                _bcd2bin(self.buffer[6] & self.mask_datetime[6]),
+                _bcd2bin(self.buffer[5 - self.weekday_offset] & self.mask_datetime[4]),
+                _bcd2bin(self.buffer[3] & self.mask_datetime[3]),
+                _bcd2bin(self.buffer[2] & self.mask_datetime[2]),
+                _bcd2bin(self.buffer[1] & self.mask_datetime[1]),
+                _bcd2bin(
+                    (self.buffer[4 + self.weekday_offset] & self.mask_datetime[5])
+                    - self.weekday_start
+                ),
+                -1,
+                -1,
+            )
+        )
+
+    def __set__(self, obj: I2CDeviceDriver, value: time.struct_time) -> None:
+        self.buffer[1] = _bin2bcd(value.tm_sec) & 0x7F  # format conversions
+        self.buffer[2] = _bin2bcd(value.tm_min)
+        self.buffer[3] = _bin2bcd(value.tm_hour)
+        self.buffer[4 + self.weekday_offset] = _bin2bcd(value.tm_wday + self.weekday_start)
+        self.buffer[5 - self.weekday_offset] = _bin2bcd(value.tm_mday)
+        self.buffer[6] = _bin2bcd(value.tm_mon)
+        self.buffer[7] = _bin2bcd(value.tm_year - 2000)
+        with obj.i2c_device:
+            obj.i2c_device.write(self.buffer)

--- a/firmware/lib/adafruit_register/i2c_bit.py
+++ b/firmware/lib/adafruit_register/i2c_bit.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2016 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_register.i2c_bit`
+====================================================
+
+Single bit registers
+
+* Author(s): Scott Shawcroft
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+try:
+    from typing import NoReturn, Optional, Type
+
+    from circuitpython_typing.device_drivers import I2CDeviceDriver
+except ImportError:
+    pass
+
+
+class RWBit:
+    """
+    Single bit register that is readable and writeable.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param int bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from I2C the LSB? Defaults to true
+
+    """
+
+    def __init__(
+        self,
+        register_address: int,
+        bit: int,
+        register_width: int = 1,
+        lsb_first: bool = True,
+    ) -> None:
+        self.bit_mask = 1 << (bit % 8)  # the bitmask *within* the byte!
+        self.buffer = bytearray(1 + register_width)
+        self.buffer[0] = register_address
+        if lsb_first:
+            self.byte = bit // 8 + 1  # the byte number within the buffer
+        else:
+            self.byte = register_width - (bit // 8)  # the byte number within the buffer
+
+    def __get__(
+        self,
+        obj: Optional[I2CDeviceDriver],
+        objtype: Optional[Type[I2CDeviceDriver]] = None,
+    ) -> bool:
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
+        return bool(self.buffer[self.byte] & self.bit_mask)
+
+    def __set__(self, obj: I2CDeviceDriver, value: bool) -> None:
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
+            if value:
+                self.buffer[self.byte] |= self.bit_mask
+            else:
+                self.buffer[self.byte] &= ~self.bit_mask
+            i2c.write(self.buffer)
+
+
+class ROBit(RWBit):
+    """Single bit register that is read only. Subclass of `RWBit`.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param type bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+
+    """
+
+    def __set__(self, obj: I2CDeviceDriver, value: bool) -> NoReturn:
+        raise AttributeError()

--- a/firmware/lib/adafruit_register/i2c_bits.py
+++ b/firmware/lib/adafruit_register/i2c_bits.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2016 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_register.i2c_bits`
+====================================================
+
+Multi bit registers
+
+* Author(s): Scott Shawcroft
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+try:
+    from typing import NoReturn, Optional, Type
+
+    from circuitpython_typing.device_drivers import I2CDeviceDriver
+except ImportError:
+    pass
+
+
+class RWBits:
+    """
+    Multibit register (less than a full byte) that is readable and writeable.
+    This must be within a byte register.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param int lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from I2C the LSB? Defaults to true
+    :param bool signed: If True, the value is a "two's complement" signed value.
+                        If False, it is unsigned.
+    """
+
+    def __init__(
+        self,
+        num_bits: int,
+        register_address: int,
+        lowest_bit: int,
+        register_width: int = 1,
+        lsb_first: bool = True,
+        signed: bool = False,
+    ) -> None:
+        self.bit_mask = ((1 << num_bits) - 1) << lowest_bit
+        # print("bitmask: ",hex(self.bit_mask))
+        if self.bit_mask >= 1 << (register_width * 8):
+            raise ValueError("Cannot have more bits than register size")
+        self.lowest_bit = lowest_bit
+        self.buffer = bytearray(1 + register_width)
+        self.buffer[0] = register_address
+        self.lsb_first = lsb_first
+        self.sign_bit = (1 << (num_bits - 1)) if signed else 0
+
+    def __get__(
+        self,
+        obj: Optional[I2CDeviceDriver],
+        objtype: Optional[Type[I2CDeviceDriver]] = None,
+    ) -> int:
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
+        # read the number of bytes into a single variable
+        reg = 0
+        order = range(len(self.buffer) - 1, 0, -1)
+        if not self.lsb_first:
+            order = reversed(order)
+        for i in order:
+            reg = (reg << 8) | self.buffer[i]
+        reg = (reg & self.bit_mask) >> self.lowest_bit
+        # If the value is signed and negative, convert it
+        if reg & self.sign_bit:
+            reg -= 2 * self.sign_bit
+        return reg
+
+    def __set__(self, obj: I2CDeviceDriver, value: int) -> None:
+        value <<= self.lowest_bit  # shift the value over to the right spot
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
+            reg = 0
+            order = range(len(self.buffer) - 1, 0, -1)
+            if not self.lsb_first:
+                order = range(1, len(self.buffer))
+            for i in order:
+                reg = (reg << 8) | self.buffer[i]
+            # print("old reg: ", hex(reg))
+            reg &= ~self.bit_mask  # mask off the bits we're about to change
+            reg |= value  # then or in our new value
+            # print("new reg: ", hex(reg))
+            for i in reversed(order):
+                self.buffer[i] = reg & 0xFF
+                reg >>= 8
+            i2c.write(self.buffer)
+
+
+class ROBits(RWBits):
+    """
+    Multibit register (less than a full byte) that is read-only. This must be
+    within a byte register.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param type lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    """
+
+    def __set__(self, obj: I2CDeviceDriver, value: int) -> NoReturn:
+        raise AttributeError()

--- a/firmware/lib/adafruit_register/i2c_struct.py
+++ b/firmware/lib/adafruit_register/i2c_struct.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2016 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_register.i2c_struct`
+====================================================
+
+Generic structured registers based on `struct`
+
+* Author(s): Scott Shawcroft
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+import struct
+
+try:
+    from typing import Any, NoReturn, Optional, Tuple, Type
+
+    from circuitpython_typing.device_drivers import I2CDeviceDriver
+except ImportError:
+    pass
+
+
+class Struct:
+    """
+    Arbitrary structure register that is readable and writeable.
+
+    Values are tuples that map to the values in the defined struct.  See struct
+    module documentation for struct format string and its possible value types.
+
+    :param int register_address: The register address to read the bit from
+    :param str struct_format: The struct format string for this register.
+    """
+
+    def __init__(self, register_address: int, struct_format: str) -> None:
+        self.format = struct_format
+        self.buffer = bytearray(1 + struct.calcsize(self.format))
+        self.buffer[0] = register_address
+
+    def __get__(
+        self,
+        obj: Optional[I2CDeviceDriver],
+        objtype: Optional[Type[I2CDeviceDriver]] = None,
+    ) -> Tuple:
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
+        return struct.unpack_from(self.format, memoryview(self.buffer)[1:])
+
+    def __set__(self, obj: I2CDeviceDriver, value: Tuple) -> None:
+        struct.pack_into(self.format, self.buffer, 1, *value)
+        with obj.i2c_device as i2c:
+            i2c.write(self.buffer)
+
+
+class UnaryStruct:
+    """
+    Arbitrary single value structure register that is readable and writeable.
+
+    Values map to the first value in the defined struct.  See struct
+    module documentation for struct format string and its possible value types.
+
+    :param int register_address: The register address to read the bit from
+    :param str struct_format: The struct format string for this register.
+    """
+
+    def __init__(self, register_address: int, struct_format: str) -> None:
+        self.format = struct_format
+        self.address = register_address
+
+    def __get__(
+        self,
+        obj: Optional[I2CDeviceDriver],
+        objtype: Optional[Type[I2CDeviceDriver]] = None,
+    ) -> Any:
+        buf = bytearray(1 + struct.calcsize(self.format))
+        buf[0] = self.address
+        with obj.i2c_device as i2c:
+            i2c.write_then_readinto(buf, buf, out_end=1, in_start=1)
+        return struct.unpack_from(self.format, buf, 1)[0]
+
+    def __set__(self, obj: I2CDeviceDriver, value: Any) -> None:
+        buf = bytearray(1 + struct.calcsize(self.format))
+        buf[0] = self.address
+        struct.pack_into(self.format, buf, 1, value)
+        with obj.i2c_device as i2c:
+            i2c.write(buf)
+
+
+class ROUnaryStruct(UnaryStruct):
+    """
+    Arbitrary single value structure register that is read-only.
+
+    Values map to the first value in the defined struct.  See struct
+    module documentation for struct format string and its possible value types.
+
+    :param int register_address: The register address to read the bit from
+    :param type struct_format: The struct format string for this register.
+    """
+
+    def __set__(self, obj: I2CDeviceDriver, value: Any) -> NoReturn:
+        raise AttributeError()

--- a/firmware/lib/adafruit_register/i2c_struct_array.py
+++ b/firmware/lib/adafruit_register/i2c_struct_array.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_register.i2c_struct_array`
+====================================================
+
+Array of structured registers based on `struct`
+
+* Author(s): Scott Shawcroft
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+import struct
+
+try:
+    from typing import Optional, Tuple, Type
+
+    from circuitpython_typing.device_drivers import I2CDeviceDriver
+except ImportError:
+    pass
+
+
+class _BoundStructArray:
+    """
+    Array object that `StructArray` constructs on demand.
+
+    :param object obj: The device object to bind to. It must have a `i2c_device` attribute
+    :param int register_address: The register address to read the bit from
+    :param str struct_format: The struct format string for each register element
+    :param int count: Number of elements in the array
+    """
+
+    def __init__(
+        self,
+        obj: I2CDeviceDriver,
+        register_address: int,
+        struct_format: str,
+        count: int,
+    ) -> None:
+        self.format = struct_format
+        self.first_register = register_address
+        self.obj = obj
+        self.count = count
+
+    def _get_buffer(self, index: int) -> bytearray:
+        """Shared bounds checking and buffer creation."""
+        if not 0 <= index < self.count:
+            raise IndexError()
+        size = struct.calcsize(self.format)
+        # We create the buffer every time instead of keeping the buffer (which is 32 bytes at least)
+        # around forever.
+        buf = bytearray(size + 1)
+        buf[0] = self.first_register + size * index
+        return buf
+
+    def __getitem__(self, index: int) -> Tuple:
+        buf = self._get_buffer(index)
+        with self.obj.i2c_device as i2c:
+            i2c.write_then_readinto(buf, buf, out_end=1, in_start=1)
+        return struct.unpack_from(self.format, buf, 1)  # offset=1
+
+    def __setitem__(self, index: int, value: Tuple) -> None:
+        buf = self._get_buffer(index)
+        struct.pack_into(self.format, buf, 1, *value)
+        with self.obj.i2c_device as i2c:
+            i2c.write(buf)
+
+    def __len__(self) -> int:
+        return self.count
+
+
+class StructArray:
+    """
+    Repeated array of structured registers that are readable and writeable.
+
+    Based on the index, values are offset by the size of the structure.
+
+    Values are tuples that map to the values in the defined struct.  See struct
+    module documentation for struct format string and its possible value types.
+
+    .. note:: This assumes the device addresses correspond to 8-bit bytes. This is not suitable for
+      devices with registers of other widths such as 16-bit.
+
+    :param int register_address: The register address to begin reading the array from
+    :param str struct_format: The struct format string for this register.
+    :param int count: Number of elements in the array
+    """
+
+    def __init__(self, register_address: int, struct_format: str, count: int) -> None:
+        self.format = struct_format
+        self.address = register_address
+        self.count = count
+        self.array_id = f"_structarray{register_address}"
+
+    def __get__(
+        self,
+        obj: Optional[I2CDeviceDriver],
+        objtype: Optional[Type[I2CDeviceDriver]] = None,
+    ) -> _BoundStructArray:
+        # We actually can't handle the indexing ourself due to data descriptor limits. So, we return
+        # an object that can instead. This object is bound to the object passed in here by its
+        # initializer and then cached on the object itself. That way its lifetime is tied to the
+        # lifetime of the object itself.
+        if not hasattr(obj, self.array_id):
+            setattr(
+                obj,
+                self.array_id,
+                _BoundStructArray(obj, self.address, self.format, self.count),
+            )
+        return getattr(obj, self.array_id)

--- a/firmware/lib/adafruit_register/register_accessor.py
+++ b/firmware/lib/adafruit_register/register_accessor.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Max Holliday
+# SPDX-FileCopyrightText: Copyright (c) 2025 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_register.register_accessor`
+====================================================
+
+SPI and I2C Register Accessor classes.
+
+* Author(s): Max Holliday
+* Adaptation by Tim Cocks
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+try:
+    from typing import Union
+
+    from adafruit_bus_device.i2c_device import I2CDevice
+    from adafruit_bus_device.spi_device import SPIDevice
+except ImportError:
+    pass
+
+
+class RegisterAccessor:
+    """
+    Subclasses of this class will be used to provide read/write interface to registers
+    over different bus types.
+
+    :param int address_width: The width of the register addresses in bytes. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from the bus the LSB? Defaults to true
+    """
+
+    address_width = None
+
+    def __init__(self, address_width=1, lsb_first=True):
+        self.address_width = address_width
+        self.address_buffer = bytearray(address_width)
+        self.lsb_first = lsb_first
+
+    def _pack_address_into_buffer(self, address):
+        if self.lsb_first:
+            # Little-endian: least significant byte first
+            for address_byte_i in range(self.address_width):
+                self.address_buffer[address_byte_i] = (address >> (address_byte_i * 8)) & 0xFF
+        else:
+            # Big-endian: most significant byte first
+            big_endian_address = address.to_bytes(self.address_width, byteorder="big")
+            for address_byte_i in range(self.address_width):
+                self.address_buffer[address_byte_i] = big_endian_address[address_byte_i]
+
+
+class SPIRegisterAccessor(RegisterAccessor):
+    """
+    RegisterAccessor class for SPI bus transport. Provides interface to read/write
+    registers over SPI. This class automatically handles the R/W bit by setting the
+    highest bit of the address to 1 when reading and 0 when writing. For multi-byte
+    addresses the R/W bit will be set as the highest bit in the first byte of the
+    address.
+
+    :param SPIDevice spi_device: The SPI bus device to communicate over.
+    :param int address_width: The number of bytes in the address
+    """
+
+    def __init__(self, spi_device: SPIDevice, address_width: int = 1, lsb_first=True):
+        super().__init__(address_width, lsb_first)
+        self.spi_device = spi_device
+
+    def _shift_rw_cmd_bit_into_first_byte(self, bit_value):
+        if bit_value not in {0, 1}:
+            raise ValueError("bit_value must be 0 or 1")
+
+        # Clear the MSB (set bit 7 to 0)
+        cleared_byte = self.address_buffer[0] & 0x7F
+        # Set the MSB to the desired bit value
+        self.address_buffer[0] = cleared_byte | (bit_value << 7)
+
+    def read_register(self, address: int, buffer: bytearray):
+        """
+        Read register value over SPIDevice.
+
+        :param int address: The register address to read.
+        :param bytearray buffer: Buffer that will be used to read register data into.
+        :return: None
+        """
+
+        self._pack_address_into_buffer(address)
+        self._shift_rw_cmd_bit_into_first_byte(1)
+        with self.spi_device as spi:
+            spi.write(self.address_buffer)
+            spi.readinto(buffer)
+
+    def write_register(
+        self,
+        address: int,
+        buffer: bytearray,
+    ):
+        """
+        Write register value over SPIDevice.
+
+        :param int address: The register address to read.
+        :param bytearray buffer: Buffer that will be written to the register.
+        :return: None
+        """
+        self._pack_address_into_buffer(address)
+        self._shift_rw_cmd_bit_into_first_byte(0)
+        with self.spi_device as spi:
+            spi.write(self.address_buffer)
+            spi.write(buffer)
+
+
+class I2CRegisterAccessor(RegisterAccessor):
+    """
+    RegisterAccessor class for I2C bus transport. Provides interface to read/write
+    registers over I2C. This class uses `adafruit_bus_device.I2CDevice` for
+    communication. I2CDevice automatically handles the R/W bit by setting
+    the lowest bit of the device address to 1 for reading and 0 for writing.
+    Device address & r/w bit will be written first, followed by register address,
+    then the data will be written or read.
+
+    :param I2CDevice i2c_device: I2C device to communicate over
+    :param int address_width: The number of bytes in the address
+    """
+
+    def __init__(self, i2c_device: I2CDevice, address_width: int = 1, lsb_first=True):
+        super().__init__(address_width, lsb_first)
+        self.i2c_device = i2c_device
+
+        # buffer that will hold address + data for write operations, will grow as needed
+        self._full_buffer = bytearray(address_width + 1)
+
+    def read_register(self, address: int, buffer: bytearray):
+        """
+        Read register value over I2CDevice.
+
+        :param int address: The register address to read.
+        :param bytearray buffer: Buffer that will be used to read register data into.
+        :return: None
+        """
+
+        self._pack_address_into_buffer(address)
+        with self.i2c_device as i2c:
+            i2c.write_then_readinto(self.address_buffer, buffer)
+
+    def write_register(self, address: int, buffer: bytearray):
+        """
+        Write register value over I2CDevice.
+
+        :param int address: The register address to read.
+        :param bytearray buffer: Buffer of data that will be written to the register.
+        :return: None
+        """
+        # grow full buffer if needed
+        if self.address_width + len(buffer) > len(self._full_buffer):
+            self._full_buffer = bytearray(self.address_width + len(buffer))
+
+        # put address into full buffer
+        self._pack_address_into_buffer(address)
+        self._full_buffer[: self.address_width] = self.address_buffer
+
+        # put data into full buffer
+        self._full_buffer[self.address_width : self.address_width + len(buffer)] = buffer
+
+        with self.i2c_device as i2c:
+            i2c.write(self._full_buffer, end=self.address_width + len(buffer))

--- a/firmware/lib/adafruit_register/register_bit.py
+++ b/firmware/lib/adafruit_register/register_bit.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_register.register_bit`
+====================================================
+
+Single bit registers that use RegisterAccessor
+
+* Author(s): Tim Cocks
+
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+
+class RWBit:
+    """
+    Single bit register that is readable and writeable.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param int bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from spi the LSB? Defaults to true
+
+    """
+
+    def __init__(
+        self, register_address: int, bit: int, register_width: int = 1, lsb_first: bool = True
+    ):
+        self.bit_mask = 1 << (bit % 8)  # the bitmask *within* the byte!
+
+        self.address = register_address
+
+        self.buffer = bytearray(register_width)
+
+        self.lsb_first = lsb_first
+        self.bit_index = bit
+        if lsb_first:
+            self.byte = bit // 8  # Little-endian: bit 0 in first register byte
+        else:
+            self.byte = register_width - 1 - (bit // 8)  # Big-endian: bit 0 in last register byte
+
+    def __get__(self, obj, objtype=None):
+        # read data from register
+        obj.register_accessor.read_register(self.address, self.buffer)
+
+        # check specified bit and return boolean
+        return bool(self.buffer[self.byte] & self.bit_mask)
+
+    def __set__(self, obj, value):
+        # read current data from register
+        obj.register_accessor.read_register(self.address, self.buffer)
+
+        # update current data with new value
+        if value:
+            self.buffer[self.byte] |= self.bit_mask
+        else:
+            self.buffer[self.byte] &= ~self.bit_mask
+
+        # write updated data to register
+        obj.register_accessor.write_register(self.address, self.buffer)
+
+
+class ROBit(RWBit):
+    """Single bit register that is read only. Subclass of `RWBit`.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param type bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+
+    """
+
+    def __set__(self, obj, value):
+        raise AttributeError()

--- a/firmware/lib/adafruit_register/register_bits.py
+++ b/firmware/lib/adafruit_register/register_bits.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_register.register_bits`
+====================================================
+
+Multi bit registers
+
+* Author(s): Tim Cocks
+
+"""
+
+__version__ = "1.11.3"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
+
+class RWBits:
+    """
+    Multibit register that is readable and writeable.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param int lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from the bus the LSB? Defaults to true
+    :param bool signed: If True, the value is a "two's complement" signed value.
+      If False, it is unsigned.
+
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        num_bits: int,
+        register_address: int,
+        lowest_bit: int,
+        register_width: int = 1,
+        lsb_first: bool = True,
+        signed: bool = False,
+    ):
+        self.bit_mask = ((1 << num_bits) - 1) << lowest_bit
+
+        if self.bit_mask >= 1 << (register_width * 8):
+            raise ValueError("Cannot have more bits than register size")
+        self.lowest_bit = lowest_bit
+
+        self.address = register_address
+        self.buffer = bytearray(register_width)
+
+        self.lsb_first = lsb_first
+        self.sign_bit = (1 << (num_bits - 1)) if signed else 0
+
+    def __get__(self, obj, objtype=None):
+        # read data from register
+        obj.register_accessor.read_register(self.address, self.buffer)
+
+        # read the bytes into a single variable
+        reg = 0
+        order = range(len(self.buffer) - 1, -1, -1)
+        if not self.lsb_first:
+            order = reversed(order)
+        for i in order:
+            reg = (reg << 8) | self.buffer[i]
+
+        # extract integer value from specified bits
+        result = (reg & self.bit_mask) >> self.lowest_bit
+
+        # If the value is signed and negative, convert it
+        if result & self.sign_bit:
+            result -= 2 * self.sign_bit
+
+        return result
+
+    def __set__(self, obj, value):
+        # read current data from register
+        obj.register_accessor.read_register(self.address, self.buffer)
+
+        # shift in integer value to register data
+        reg = 0
+        order = range(len(self.buffer) - 1, -1, -1)
+        if not self.lsb_first:
+            order = reversed(order)
+        for i in order:
+            reg = (reg << 8) | self.buffer[i]
+        shifted_value = value << self.lowest_bit
+        reg &= ~self.bit_mask  # mask off the bits we're about to change
+        reg |= shifted_value  # then or in our new value
+
+        # put data from reg back into buffer
+        for i in reversed(order):
+            self.buffer[i] = reg & 0xFF
+            reg >>= 8
+
+        # write updated data buffer to the register
+        obj.register_accessor.write_register(self.address, self.buffer)
+
+
+class ROBits(RWBits):
+    """
+    Multibit register that is read-only.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param int lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from the bus the LSB? Defaults to true
+    :param bool signed: If True, the value is a "two's complement" signed value.
+      If False, it is unsigned.
+    """
+
+    def __set__(self, obj, value):
+        raise AttributeError()

--- a/firmware/lib/bmp581.py
+++ b/firmware/lib/bmp581.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 Jose D. Montoya
+#
+# SPDX-License-Identifier: MIT
+"""
+`bmp581`
+================================================================================
+
+CircuitPython Driver for the Bosch BMP581 pressure sensor
+
+
+* Author(s): Jose D. Montoya
+
+
+"""
+
+from micropython import const
+from adafruit_bus_device import i2c_device
+from adafruit_register.i2c_struct import ROUnaryStruct
+from adafruit_register.i2c_bits import RWBits, ROBits
+
+try:
+    from busio import I2C
+except ImportError:
+    pass
+
+__version__ = "0.2.0"
+__repo__ = "https://github.com/jposada202020/CircuitPython_BMP581.git"
+
+_REG_WHOAMI = const(0x01)
+_OSR_CONF = const(0x36)
+_ODR_CONFIG = const(0x37)
+
+
+# Power Modes
+STANDBY = const(0x00)
+NORMAL = const(0x01)
+FORCED = const(0x02)
+NON_STOP = const(0x03)
+power_mode_values = (STANDBY, NORMAL, FORCED, NON_STOP)
+
+
+# Oversample Rate
+OSR1 = const(0x00)
+OSR2 = const(0x01)
+OSR4 = const(0x02)
+OSR8 = const(0x03)
+OSR16 = const(0x04)
+OSR32 = const(0x05)
+OSR64 = const(0x06)
+OSR128 = const(0x07)
+pressure_oversample_rate_values = (OSR1, OSR2, OSR4, OSR8, OSR16, OSR32, OSR64, OSR128)
+temperature_oversample_rate_values = (
+    OSR1,
+    OSR2,
+    OSR4,
+    OSR8,
+    OSR16,
+    OSR32,
+    OSR64,
+    OSR128,
+)
+
+
+class BMP581:
+    """Driver for the BMP581 Sensor connected over I2C.
+
+    :param ~busio.I2C i2c_bus: The I2C bus the BMP581 is connected to.
+    :param int address: The I2C device address. Defaults to :const:`0x47`
+
+    :raises RuntimeError: if the sensor is not found
+
+    **Quickstart: Importing and using the device**
+
+    Here is an example of using the :class:`BMP581` class.
+    First you will need to import the libraries to use the sensor
+
+    .. code-block:: python
+
+        import board
+        import bmp581
+
+    Once this is done you can define your `board.I2C` object and define your sensor object
+
+    .. code-block:: python
+
+        i2c = board.I2C()  # uses board.SCL and board.SDA
+        bmp = bmp581.BMP581(i2c)
+
+    Now you have access to the attributes
+
+    .. code-block:: python
+
+        press = bmp.pressure
+
+    """
+
+    _device_id = ROUnaryStruct(_REG_WHOAMI, "B")
+
+    _power_mode = RWBits(2, _ODR_CONFIG, 0)
+    _temperature_oversample_rate = RWBits(3, _OSR_CONF, 0)
+    _pressure_oversample_rate = RWBits(3, _OSR_CONF, 3)
+    _output_data_rate = RWBits(5, _ODR_CONFIG, 2)
+    _pressure_enabled = RWBits(1, _OSR_CONF, 6)
+
+    _temperature = ROBits(24, 0x1D, 0, 3)
+    _pressure = ROBits(24, 0x20, 0, 3)
+
+    def __init__(self, i2c_bus: I2C, address: int = 0x47) -> None:
+        self.i2c_device = i2c_device.I2CDevice(i2c_bus, address)
+
+        if self._device_id != 0x50:
+            raise RuntimeError("Failed to find BMP581")
+
+        self._power_mode = NORMAL
+        self._pressure_enabled = True
+        self.sea_level_pressure = 101.325
+
+    @property
+    def power_mode(self) -> str:
+        """
+        Sensor power_mode
+
+        +-----------------------------+------------------+
+        | Mode                        | Value            |
+        +=============================+==================+
+        | :py:const:`bmp581.STANDBY`  | :py:const:`0x00` |
+        +-----------------------------+------------------+
+        | :py:const:`bmp581.NORMAL`   | :py:const:`0x01` |
+        +-----------------------------+------------------+
+        | :py:const:`bmp581.FORCED`   | :py:const:`0x02` |
+        +-----------------------------+------------------+
+        | :py:const:`bmp581.NON_STOP` | :py:const:`0X03` |
+        +-----------------------------+------------------+
+        """
+        values = (
+            "STANDBY",
+            "NORMAL",
+            "FORCED",
+            "NON_STOP",
+        )
+        return values[self._power_mode]
+
+    @power_mode.setter
+    def power_mode(self, value: int) -> None:
+        if value not in power_mode_values:
+            raise ValueError("Value must be a valid power_mode setting")
+        self._power_mode = value
+
+    @property
+    def pressure_oversample_rate(self) -> str:
+        """
+        Sensor pressure_oversample_rate
+
+        +---------------------------+------------------+
+        | Mode                      | Value            |
+        +===========================+==================+
+        | :py:const:`bmp581.OSR1`   | :py:const:`0x00` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR2`   | :py:const:`0x01` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR4`   | :py:const:`0x02` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR8`   | :py:const:`0x03` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR16`  | :py:const:`0x04` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR32`  | :py:const:`0x05` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR64`  | :py:const:`0x06` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR128` | :py:const:`0x07` |
+        +---------------------------+------------------+
+        """
+        values = (
+            "OSR1",
+            "OSR2",
+            "OSR4",
+            "OSR8",
+            "OSR16",
+            "OSR32",
+            "OSR64",
+            "OSR128",
+        )
+        return values[self._pressure_oversample_rate]
+
+    @pressure_oversample_rate.setter
+    def pressure_oversample_rate(self, value: int) -> None:
+        if value not in pressure_oversample_rate_values:
+            raise ValueError("Value must be a valid pressure_oversample_rate setting")
+        self._pressure_oversample_rate = value
+
+    @property
+    def temperature_oversample_rate(self) -> str:
+        """
+        Sensor temperature_oversample_rate
+
+        +---------------------------+------------------+
+        | Mode                      | Value            |
+        +===========================+==================+
+        | :py:const:`bmp581.OSR1`   | :py:const:`0x00` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR2`   | :py:const:`0x01` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR4`   | :py:const:`0x02` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR8`   | :py:const:`0x03` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR16`  | :py:const:`0x04` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR32`  | :py:const:`0x05` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR64`  | :py:const:`0x06` |
+        +---------------------------+------------------+
+        | :py:const:`bmp581.OSR128` | :py:const:`0x07` |
+        +---------------------------+------------------+
+        """
+        values = (
+            "OSR1",
+            "OSR2",
+            "OSR4",
+            "OSR8",
+            "OSR16",
+            "OSR32",
+            "OSR64",
+            "OSR128",
+        )
+        return values[self._temperature_oversample_rate]
+
+    @temperature_oversample_rate.setter
+    def temperature_oversample_rate(self, value: int) -> None:
+        if value not in temperature_oversample_rate_values:
+            raise ValueError(
+                "Value must be a valid temperature_oversample_rate setting"
+            )
+        self._temperature_oversample_rate = value
+
+    @property
+    def output_data_rate(self) -> int:
+        """
+        Sensor output_data_rate. for a complete list of values please see the datasheet
+
+        """
+
+        return self._output_data_rate
+
+    @output_data_rate.setter
+    def output_data_rate(self, value: int) -> None:
+        if value not in range(0, 32, 1):
+            raise ValueError("Value must be a valid output_data_rate setting")
+        self._output_data_rate = value
+
+    @property
+    def temperature(self) -> float:
+        """
+        The temperature sensor in C
+        :return: Temperature
+        """
+        raw_temp = self._temperature
+
+        return self._twos_comp(raw_temp, 24) / 2**16.0
+
+    @property
+    def pressure(self) -> float:
+        """
+        The sensor pressure in kPa
+        :return: Pressure in kPa
+        """
+        raw_pressure = self._pressure
+
+        return self._twos_comp(raw_pressure, 24) / 2**6 / 1000
+
+    @property
+    def altitude(self):
+        """
+        With the measured pressure p and the pressure at sea level p0 e.g. 1013.25hPa,
+        the altitude in meters can be calculated with the international barometric formula
+
+        With the measured pressure p and the absolute altitude the pressure at sea level
+        can be calculated too. See the altitude setter for this calculation
+        """
+
+        altitude = 44330.0 * (
+            1.0 - ((self.pressure / self.sea_level_pressure) ** 0.190284)
+        )
+        return round(altitude, 1)
+
+    @altitude.setter
+    def altitude(self, value: float) -> None:
+        self.sea_level_pressure = self.pressure / (1.0 - value / 44330.0) ** 5.255
+
+    @staticmethod
+    def _twos_comp(val: int, bits: int) -> int:
+
+        if val & (1 << (bits - 1)) != 0:
+            return val - (1 << bits)
+        return val

--- a/firmware/readme.md
+++ b/firmware/readme.md
@@ -51,6 +51,8 @@ Führe nun Circup aus, um die benötigten Bibliotheken zu installieren:
 circup install --auto
 ```
 
+Der **Bosch BMP581**-Treiber (`lib/bmp581.py`, v0.2.0) und die Abhängigkeit `lib/adafruit_register/` sind in der Firmware enthalten. Ein separates `circup install bmp581` ist nur nötig, wenn du die gebündelte Version überschreiben willst.
+
 Für **Air Station im Wifiless-Modus** (Messdaten auf SD-Karte) zusätzlich:
 
 ```bash
@@ -217,6 +219,7 @@ Aktuell unterstützte Sensor-IDs:
 | 7 | SHT31 | Temp, Hum |
 | 8 | AGS02MA | VOCs (absolut), Gaswiderstand |
 | 9 | SHT4X | Temp, Hum |
+| 28 | BMP581 | Temp, Druck, Höhe |
 
 
 ### Luftdaten-Gerät-Details auslesen (geändert in v2)

--- a/firmware/sensors/sensor_bmp581.py
+++ b/firmware/sensors/sensor_bmp581.py
@@ -1,0 +1,51 @@
+import bmp581  # type: ignore
+
+from sensors.sensor import Sensor
+from enums import Dimension, SensorModel, Quality
+from logger import logger
+
+_BMP581_I2C_ADDRESSES = (0x47, 0x46)
+
+
+class Bmp581Sensor(Sensor):
+    def __init__(self):
+        super().__init__()
+        self.model_id = SensorModel.BMP581
+        self.measures_values = [
+            Dimension.TEMPERATURE,
+            Dimension.PRESSURE,
+            Dimension.ALTITUDE,
+        ]
+        self.current_values = {
+            Dimension.TEMPERATURE: None,
+            Dimension.PRESSURE: None,
+            Dimension.ALTITUDE: None,
+        }
+        self.value_quality = {
+            Dimension.TEMPERATURE: Quality.HIGH,
+            Dimension.PRESSURE: Quality.HIGH,
+            Dimension.ALTITUDE: Quality.HIGH,
+        }
+
+    def attempt_connection(self, i2c):
+        for address in _BMP581_I2C_ADDRESSES:
+            try:
+                self.bmp = bmp581.BMP581(i2c, address=address)
+                logger.debug("Bmp581 sensor found at 0x%02x" % address)
+                return True
+            except (RuntimeError, OSError, ValueError):
+                logger.debug("Bmp581 sensor not found at 0x%02x" % address)
+
+        logger.debug("Bmp581 sensor not detected")
+        return False
+
+    def read(self):
+        try:
+            self.current_values = {
+                Dimension.TEMPERATURE: self.bmp.temperature,
+                # Driver returns kPa; firmware uses hPa (Dimension.PRESSURE).
+                Dimension.PRESSURE: self.bmp.pressure * 10,
+                Dimension.ALTITUDE: self.bmp.altitude,
+            }
+        except Exception:
+            logger.error("Bmp581 read error")

--- a/firmware/util.py
+++ b/firmware/util.py
@@ -16,6 +16,7 @@ def get_connected_sensors(i2c):
         from sensors.sensor_sht4x import Sht4xSensor
         from sensors.sensor_sgp40 import Sgp40Sensor
         from sensors.sensor_bmp3xx import Bmp3xxSensor
+        from sensors.sensor_bmp581 import Bmp581Sensor
         from sensors.sensor_ltr390 import Ltr390Sensor
         from sensors.sensor_lsm6ds import Lsm6dsSensor
         from sensors.sensor_sen62 import Sen62Sensor
@@ -38,6 +39,7 @@ def get_connected_sensors(i2c):
             Sht4xSensor(),
             Sgp40Sensor(),
             Bmp3xxSensor(),
+            Bmp581Sensor(),
             Ltr390Sensor(),
             Lsm6dsSensor(),
             Sen62Sensor(),


### PR DESCRIPTION
This commit introduces support for the Bosch BMP581 sensor, including its integration into the firmware with a new sensor class. The enums and utility functions have been updated to accommodate the BMP581, and the README has been revised to include installation instructions and details about the sensor's capabilities. Additionally, the supported sensor IDs table has been updated to reflect the new sensor.